### PR TITLE
Apply dark mode to user info panel

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -147,6 +147,14 @@ body.dark-mode .rc-member-list__user:hover {
 	background-color: var(--color-darkest);
 }
 
+body.dark-mode .rc-user-info-details {
+  background-color: var(--color-dark-medium);
+}
+
+body.dark-mode .rc-user-info-details__info {
+  color: var(--color-white);
+}
+
 body.dark-mode select option {
 	color: var(--color-dark);
 }

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -102,9 +102,9 @@ body.dark-mode {
 	--input-icon-color: var(--color-gray-lightest);
 
 	--mention-link-text-color: var(--color-light-blue);
-  --mention-link-background: var(--color-dark-medium);
+	--mention-link-background: var(--color-dark-medium);
 
-  --chip-background: var(--color-blue);
+	--chip-background: var(--color-blue);
 }
 
 

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -148,11 +148,11 @@ body.dark-mode .rc-member-list__user:hover {
 }
 
 body.dark-mode .rc-user-info-details {
-  background-color: var(--color-dark-medium);
+	background-color: var(--color-dark-medium);
 }
 
 body.dark-mode .rc-user-info-details__info {
-  color: var(--color-white);
+	color: var(--color-white);
 }
 
 body.dark-mode select option {

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -102,7 +102,9 @@ body.dark-mode {
 	--input-icon-color: var(--color-gray-lightest);
 
 	--mention-link-text-color: var(--color-light-blue);
-	--mention-link-background: var(--color-dark-medium);
+  --mention-link-background: var(--color-dark-medium);
+
+  --chip-background: var(--color-blue);
 }
 
 
@@ -168,7 +170,7 @@ body.dark-mode .rc-user-info-details {
 	background-color: var(--color-dark-medium);
 }
 
-body.dark-mode .rc-user-info-details__info {
+body.dark-mode p.rc-user-info-details__info {
 	color: var(--color-white);
 }
 


### PR DESCRIPTION
Applying dark mode to a place it was missed - the user info panel that appears when you click on a user's name or avatar.

Before:
<img width="250" alt="image" src="https://user-images.githubusercontent.com/39106297/73587033-182a0400-4484-11ea-83e7-32be4d1f8435.png">

After:
<img width="250" alt="image" src="https://user-images.githubusercontent.com/39106297/73587082-c2a22700-4484-11ea-9381-847b4670db6c.png">
