### PR TITLE
Fix add user panel

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -43,6 +43,7 @@ select {
 /******************************************
  ************Transition Effect*************
  ******************************************/
+input,
 textarea,
 select,
 .color-primary-font-color,
@@ -105,6 +106,14 @@ body.dark-mode {
 	--mention-link-background: var(--color-dark-medium);
 
 	--chip-background: var(--color-blue);
+
+	--tags-background: var(--color-blue);
+	--tags-text-color: var(--color-white);
+
+	--popup-list-background: var(--color-dark);
+	--popup-list-selected-background: var(--color-dark);
+	--popup-list-name-color: var(--color-white);
+	--popup-list-background-hover: var(--color-darkest);
 }
 
 
@@ -115,6 +124,10 @@ body.dark-mode {
 
 
 /***************Main Chat*****************/
+
+body.dark-mode input {
+	color: var(--color-white);
+}
 
 body.dark-mode a {
 	color: var(--color-light-blue);


### PR DESCRIPTION
Fixes #10. There are two changes here: 1) variable settings to clean up the **Add Users** panel, and 2) setting `input` color to white universally. I want to mention that specifically since it seems like a major change.

New look for **Add Users** panel:
<img width="400" alt="image" src="https://user-images.githubusercontent.com/39106297/74873328-fd350c00-532c-11ea-8f75-0a9b5e4a4f46.png">

And when you select a user to add:
<img width="399" alt="image" src="https://user-images.githubusercontent.com/39106297/74873352-0aea9180-532d-11ea-8e4e-e41585e5fa01.png">

If universally setting the input text color to white seems like too much, somebody say so! But looking around, I think it's better that it be the default that can be overridden with specific rules where needed.
