### PR TITLE
Apply dark mode to block quote ::before

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -48,6 +48,8 @@ textarea,
 select,
 .color-primary-font-color,
 .color-info-font-color,
+.background-info-font-color,
+.background-transparent-darker-before::before,
 .messages-box .message .body, /* override for opacity transition */
 .rc-header__name,
 .rc-header__wrap,
@@ -207,6 +209,10 @@ body.dark-mode .border-component-color {
 }
 
 body.dark-mode .background-transparent-darker-before::before {
+    background-color: var(--color-dark-medium);
+}
+
+body.dark-mode .background-info-font-color {
     background-color: var(--color-dark-medium);
 }
 

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -206,6 +206,10 @@ body.dark-mode .border-component-color {
 	border-color: var(--rc-color-primary-lightest);
 }
 
+body.dark-mode .background-transparent-darker-before::before {
+    background-color: var(--color-dark-medium);
+}
+
 body.dark-mode .js-button[aria-label="Toggle Dark Mode"] {
 	filter: brightness(130%);
 }


### PR DESCRIPTION
The `::before` on blockquotes gives quotations a left margin and colored border to set them apart. In dark mode this "border" is barely visible, so I lightened it slightly.

**Edit:** I also applied this change to the "border" beside attachments, like image uploads.

Before:
<img width="79" alt="image" src="https://user-images.githubusercontent.com/39106297/75185434-15819e00-5714-11ea-88ca-5be698f4fed1.png">

After: 
<img width="79" alt="image" src="https://user-images.githubusercontent.com/39106297/75185400-04d12800-5714-11ea-99db-cd018a19a41e.png">
