### PR TITLE
Add code to translate toggle label

### DIFF
--- a/dark-mode-toggle.js
+++ b/dark-mode-toggle.js
@@ -14,7 +14,20 @@ const lightModeSymbol = `<svg id="icon-darkmode" viewBox="0 0 302.4 302.4" fill=
   <path d="m80.4,221.60001c-3.6,-4 -10.4,-4 -14.4,0l-22,22c-4,4 -4,10.40001 0,14.39999s10.4,4 14.4,0l22,-21.99998c4,-4.00002 4,-10.40001 0,-14.40001z"/>
   <path d="m80.4,66.4l-22,-22c-4,-4 -10.4,-4 -14.4,0s-4,10.4 0,14.4l22,22c4,4 10.4,4 14.4,0s4,-10.4 0,-14.4z"/>
 </svg>`; // sun icon
-const toggleButton = '<button class="sidebar__toolbar-button rc-tooltip rc-tooltip--down js-button" aria-label="Toggle Dark Mode">D</button>';
+
+const darkModeToggleText = {
+	'en': 'Toggle Dark Mode',
+	'de': 'Toggle Dark Mode',
+	'fr': 'Toggle Dark Mode',
+	'es': 'Toggle Dark Mode',
+	'it': 'Toggle Dark Mode',
+	'nl': 'Toggle Dark Mode',
+	'pl': 'Toggle Dark Mode',
+	'pt': 'Toggle Dark Mode',
+	'ru': 'Смена оформления'
+}[defaultUserLanguage()];
+
+const toggleButton = `<button class="sidebar__toolbar-button rc-tooltip rc-tooltip--down js-button" aria-label="${darkModeToggleText}">D</button>`;
 
 function isDarkModeSet() {
 	return localStorage.getItem('dark-mode') === 'true';
@@ -43,7 +56,7 @@ function addDarkModeToggle() {
 		return;
 	}
 
-	var darkModeButton = $('.js-button[aria-label="Toggle Dark Mode"]');
+	var darkModeButton = $(`.js-button[aria-label="${darkModeToggleText}"]`);
 
 	// do nothing if button is already on the screen
 	if (darkModeButton.is(':visible')) {


### PR DESCRIPTION
This translates (or will translate, once the translations get added) the label for the toggle button. I pulled the list of languages comes from [this file](https://github.com/RocketChat/Rocket.Chat/blob/0750cb6af2643fe055f31d684d13bf9b21fc799c/app/autotranslate/server/deeplTranslate.js) in the Rocket.Chat repo, but if there are more supported by Rocket.Chat, they can be added easily.