### PR TITLE
Hide tooltip on click

### DIFF
--- a/dark-mode-toggle.js
+++ b/dark-mode-toggle.js
@@ -56,7 +56,7 @@ function addDarkModeToggle() {
 	darkModeButton.on('click', function() {
 		toggleDarkMode();
 		darkModeButton.html(getDarkModeIcon());
-		$(this).tooltip('hide');
+		$(this).blur();
 	});
 }
 

--- a/dark-mode-toggle.js
+++ b/dark-mode-toggle.js
@@ -56,6 +56,7 @@ function addDarkModeToggle() {
 	darkModeButton.on('click', function() {
 		toggleDarkMode();
 		darkModeButton.html(getDarkModeIcon());
+		$(this).tooltip('hide');
 	});
 }
 


### PR DESCRIPTION
Previously, clicking on the dark mode toggle button would get it stuck in focus state, and the tool tip would never go away: 
![bad tooltip](https://user-images.githubusercontent.com/4023037/75310630-8d131280-5865-11ea-96c2-4b6aebb2e971.gif)

This change forces the tooltip to hide after being clicked, although the hover rule still applies, so it gracefully disappears like other tooltips:
![good tooltip](https://user-images.githubusercontent.com/39106297/75384184-b0f94700-58ab-11ea-8aa3-5454bc58e87b.gif)
