### PR TITLE
Dark mode v2.0

### DIFF
--- a/dark-mode-toggle.js
+++ b/dark-mode-toggle.js
@@ -25,7 +25,7 @@ const darkModeToggleText = {
 	'pl': 'Toggle Dark Mode',
 	'pt': 'Toggle Dark Mode',
 	'ru': 'Смена оформления'
-}[defaultUserLanguage()];
+}[defaultUserLanguage()] || 'Toggle Dark Mode';
 
 const toggleButton = `<button class="sidebar__toolbar-button rc-tooltip rc-tooltip--down js-button" aria-label="${darkModeToggleText}">D</button>`;
 

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -64,116 +64,62 @@ body.dark-mode {
 	--button-outline-color: var(--color-gray-medium);
 	--button-close-color: var(--color-gray-medium);
  
-	
+
 	/********************** Overridden Rocket.Chat Variables **********************/
-	/* (see `app/theme/client/imports/general/variables.css` in Rocket.Chat repo) */
 	 
 	/* General Colors */
-	 --rc-color-alert-message-warning-background: hsl(352, 83%, 20%); /* make alert warning messages have red backgrounds */
-	 --rc-color-primary: var(--color-gray-lightest); /* Sidebar background, tags text color */
-	 --rc-color-primary-lightest: var(--color-dark-medium); /* sidebar background light */
- 
-	 /* Forms - Button */
-	 --button-disabled-background: var(--color-dark-70);
-	 --button-disabled-text-color: var(--color-dark-80);
-	 --button-primary-background: var(--rc-color-button-primary);
-	 --button-primary-text-color: var(--color-white);
-	 --button-cancel-color: var(--rc-color-error);
-	 --button-secondary-background: var(--color-gray-medium);
-	 --button-secondary-text-color: var(--color-dark-medium);
- 
-	 /* Forms - Input */
-	 --input-text-color: var(--color-gray-lightest); /* Used in certain inputs and selects (with class .rc-input) */
-	 --input-icon-color: var(--color-gray-lightest); /* used in inputs with .rc-input_wrapper */
- 
-	 /* Forms - popup list */
-	--popup-list-background: var(--color-dark); /* dark colors for popup lists */
-	--popup-list-background-hover: var(--color-darkest); /* dark colors for popup lists */
-	--popup-list-selected-background: var(--color-dark); /* dark colors for popup lists */
-	--popup-list-name-color: var(--color-white); /* dark colors for popup lists */
- 
-	 /* Forms - tags */
-	 --tags-text-color: var(--color-white); /* tag (similar to chips) colors */
-	 --tags-background: var(--color-blue); /* tag (similar to chips) colors */
- 
-	 /* Sidebar */
-	 --sidebar-background: var(--color-dark); /* override; otherwise uses --rc-color-primary */
- 
-	 /* Sidebar Item */
-	 --sidebar-item-text-color: var(--rc-color-primary-light);
-	 --sidebar-item-hover-background: var(--rc-color-primary-darkest);
-	 --sidebar-item-active-background: var(--rc-color-primary-dark);
-	 --sidebar-item-active-color: var(--sidebar-item-text-color);
-	 --sidebar-item-unread-color: var(--rc-color-content);
-	 --sidebar-item-popup-background: var(--rc-color-primary-dark);
- 
-	 /* Modal */
-	 --modal-back-button-color: var(--color-gray);
- 
-	 /* Modal - Create Channel */
-	 --create-channel-title-color: var(--color-darkest);
-	 --create-channel-description-color: var(--color-gray);
- 
-	 /* Toolbar */
-	 --toolbar-placeholder-color: var(--color-gray);
- 
-	 /* Rooms list */
-	 --rooms-list-title-color: var(--rc-color-primary-light);
-	 --rooms-list-empty-text-color: var(--color-gray);
- 
-	 /* Chip */
-	 --chip-background: var(--color-blue); /* background color of "chips" (small labels) */
- 
-	 /* Badge */
-	 --badge-text-color: var(--color-white);
-	 --badge-background: var(--rc-color-primary-dark);
-	 --badge-unread-background: var(--rc-color-primary-dark);
-	 --badge-user-mentions-background: var(--color-dark-blue);
-	 --badge-group-mentions-background: var(--rc-color-primary-dark);
- 
-	 /* Mention link */
-	 --mention-link-background: var(--color-dark-medium); /* colors on username mention tag */
-	 --mention-link-text-color: var(--color-light-blue); /* colors on username mention tag */
-	 --mention-link-me-background: var(--color-dark-blue);
-	 --mention-link-me-text-color: var(--color-white);
-	 --mention-link-group-background: var(--rc-color-primary-dark);
-	 --mention-link-group-text-color: var(--color-white);
- 
-	 /* Message box */
-	 --message-box-placeholder-color: var(--color-gray-medium);
-	 --message-box-markdown-color: var(--color-gray);
-	 --message-box-markdown-hover-color: var(--color-dark);
-	 --message-box-user-typing-color: var(--color-gray-lightest); /* user typing color */
-	 --message-box-user-typing-user-color: var(--color-gray-lightest); /* user typing color */
-	 --message-box-container-border-color: var(--color-gray-medium);
-	 --message-box-editing-color: #fff5df;
-	 --message-box-popover-title-text-color: var(--color-gray);
- 
-	 /* Header */
-	 --header-toggle-favorite-color: var(--color-gray-medium);
-	 --header-toggle-favorite-star-color: var(--rc-color-alert-light);
-	 --header-toggle-encryption-off-color: var(--color-gray-medium);
-	 --header-toggle-encryption-on-color: var(--rc-color-alert-message-secondary);
-	 --header-title-username-color-darker: var(--color-gray-lightest); /* channel and user names in header */
-	 --header-title-status-color: var(--color-gray);
-	 --header-background-color: var(--color-darkest); /* The main chat screen and header */
- 
-	 /* Flex nav */
-	 --flex-nav-background: var(--color-gray-lightest);
- 
-	 /* Popover */
-	 --popover-background: var(--color-dark);
-	 --popover-title-color: var(--color-white);
-	 --popover-item-color: var(--color-white);
-	 --popover-divider-color: var(--color-gray-light);
- 
-	 /* Tooltip */
-	 --tooltip-background: var(--color-darkest);
-	 --tooltip-text-color: var(--color-white);
- 
-	 /* alert */
-	 --alerts-background: #1d73f5;
-	 --alerts-color: var(--color-white);
+	--rc-color-alert-message-warning-background: hsl(352, 83%, 20%);
+	--rc-color-primary: var(--color-gray-lightest);
+	--rc-color-primary-lightest: var(--color-dark-medium);
+
+	/* Forms - Button */
+	--button-disabled-background: var(--color-dark-70);
+	--button-disabled-text-color: var(--color-dark-80);
+
+	/* Forms - Input */
+	--input-text-color: var(--color-gray-lightest);
+	--input-icon-color: var(--color-gray-lightest);
+
+	/* Forms - popup list */
+	--popup-list-background: var(--color-dark);
+	--popup-list-background-hover: var(--color-darkest);
+	--popup-list-selected-background: var(--color-dark);
+	--popup-list-name-color: var(--color-white);
+
+	/* Forms - tags */
+	--tags-text-color: var(--color-white);
+	--tags-background: var(--color-blue);
+
+	/* Sidebar */
+	--sidebar-background: var(--color-dark);
+
+	/* Chip */
+	--chip-background: var(--color-blue);
+
+	/* Mention link */
+	--mention-link-background: var(--color-dark-medium);
+	--mention-link-text-color: var(--color-light-blue);
+
+	/* Message box */
+	--message-box-user-typing-color: var(--color-gray-lightest);
+	--message-box-user-typing-user-color: var(--color-gray-lightest);
+
+	/* Header */
+	--header-title-username-color-darker: var(--color-gray-lightest);
+	--header-background-color: var(--color-darkest);
+
+	/* Popover */
+	--popover-background: var(--color-dark);
+	--popover-title-color: var(--color-white);
+	--popover-item-color: var(--color-white);
+
+	/* Tooltip */
+	--tooltip-background: var(--color-darkest);
+	--tooltip-text-color: var(--color-white);
+
+	/* alert */
+	--alerts-background: #1d73f5;
+	--alerts-color: var(--color-white);
 }
 
 
@@ -185,16 +131,32 @@ body.dark-mode {
 
 /***************Main Chat*****************/
 
-body.dark-mode input {
-	color: var(--color-white);
-}
-
 body.dark-mode a {
 	color: var(--color-light-blue);
 }
 
 body.dark-mode .sidebar-item > a {
 	color: inherit;
+}
+
+body.dark-mode input {
+	color: var(--color-white);
+}
+
+body.dark-mode select option {
+	color: var(--color-dark);
+}
+
+body.dark-mode .rc-switch__text {
+	color: var(--color-white);
+}
+
+body.dark-mode .rc-switch-double {
+	color: var(--color-white);
+}
+
+body.dark-mode .error-border {
+	border-color: var(--color-dark-red);
 }
 
 body.dark-mode .background-component-color {
@@ -209,21 +171,8 @@ body.dark-mode .container-bars .color-primary-action-color {
 	color: var(--color-white);
 }
 
-body.dark-mode .rc-old .rc-message-box .reply-preview {
-	background-color: var(--color-dark);
-}
-
-body.dark-mode .rc-switch__text {
-	color: var(--color-white);
-}
-
 body.dark-mode .burger i {
 	background-color: var(--color-white);
-}
-
-body.dark-mode .message-actions,
-body.dark-mode .rc-member-list__counter {
-	color: var(--color-gray);
 }
 
 body.dark-mode .rc-member-list__user.active,
@@ -238,16 +187,6 @@ body.dark-mode .rc-user-info-details {
 body.dark-mode p.rc-user-info-details__info {
 	color: var(--color-white);
 }
-
-body.dark-mode select option {
-	color: var(--color-dark);
-}
-
-body.dark-mode .error-border {
-	border-color: var(--color-dark-red);
-}
-
-/* Messages and message box */
 
 body.dark-mode .messages-container .footer,
 body.dark-mode .content-background-color {
@@ -275,6 +214,15 @@ body.dark-mode .rc-message-box__container {
 	background-color: var(--message-box-background);
 }
 
+body.dark-mode .rc-old .rc-message-box .reply-preview {
+	background-color: var(--color-dark);
+}
+
+body.dark-mode .message-actions,
+body.dark-mode .rc-member-list__counter {
+	color: var(--color-gray);
+}
+
 body.dark-mode .background-transparent-darker-before::before {
     background-color: var(--color-dark-medium);
 }
@@ -282,8 +230,6 @@ body.dark-mode .background-transparent-darker-before::before {
 body.dark-mode .background-info-font-color {
     background-color: var(--color-dark-medium);
 }
-
-/* Modals */
 
 body.dark-mode .rc-modal,
 body.dark-mode .rc-modal__footer {
@@ -294,8 +240,6 @@ body.dark-mode .rc-modal__content,
 body.dark-mode .rc-modal__header {
 	color: var(--color-white);
 }
-
-/* Buttons */
 
 body.dark-mode .rc-button--outline {
 	border-color: var(--button-outline-color);
@@ -313,8 +257,6 @@ body.dark-mode .rc-button--cancel {
 	color: var(--button-primary-text-color);
 }
 
-/* Contextual bar */
-
 body.dark-mode .contextual-bar {
 	background-color: var(--color-dark);
   	border-left: 2px solid var(--color-dark-medium);
@@ -329,8 +271,6 @@ body.dark-mode .contextual-bar__content {
 	background-color: var(--color-dark);
 }
 
-/* Popovers */
-
 body.dark-mode .rc-popover__content {
 	background-color: var(--popover-background);
 	box-shadow: 0px 0px 2px var(--color-dark-20);
@@ -338,10 +278,6 @@ body.dark-mode .rc-popover__content {
 
 body.dark-mode .emoji-picker .filter-item.active {
 	border-color: var(--color-light-blue);
-}
-
-body.dark-mode .rc-switch-double {
-	color: var(--color-white);
 }
 
 body.dark-mode .rc-header--room {
@@ -400,7 +336,6 @@ body.dark-mode .hljs-type,
 body.dark-mode .hljs-number {
 	color: var(--color-orange);
 }
-
 
 
 /**************Admin Panel******************/

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -55,42 +55,27 @@ select {
  *************Dark Mode Settings***********
  ******************************************/
 body.dark-mode {
-	/************************************
-	    These are custom variables
-	************************************/
-	--primary-font-color: var(--color-gray-lightest); /* default text color if not overriden */
-	--info-font-color: var(--color-gray-light); /* message sent time */ 
-	--message-box-background: hsla(0, 0, 100%, 0.1);
- 
 
-	/************************************
-	 Variables with comments beside them
-	 are variables changed in dark mode
-	************************************/
+	/****************************** Custom Variables ******************************/
+	--primary-font-color: var(--color-gray-lightest);
+	--info-font-color: var(--color-gray-light);
+	--message-box-background: hsla(0, 0, 100%, 0.1);
+
+	--button-outline-color: var(--color-gray-medium);
+	--button-close-color: var(--color-gray-medium);
+ 
+	
+	/********************** Overridden Rocket.Chat Variables **********************/
+	/* (see `app/theme/client/imports/general/variables.css` in Rocket.Chat repo) */
 	 
 	/* General Colors */
-	 --rc-color-button-primary: var(--color-blue);
-	 --rc-color-button-primary-light: var(--color-dark-blue);
-
-	 --rc-color-alert-message-primary: var(--color-blue);
-	 --rc-color-alert-message-primary-background: #f1f6ff;
-	 --rc-color-alert-message-secondary: #7ca52b;
-	 --rc-color-alert-message-secondary-background: #fafff1;
-	 --rc-color-alert-message-warning: #d52d24;
 	 --rc-color-alert-message-warning-background: hsl(352, 83%, 20%); /* make alert warning messages have red backgrounds */
-
 	 --rc-color-primary: var(--color-gray-lightest); /* Sidebar background, tags text color */
-	 --rc-color-primary-darkest: var(--color-darkest);
-	 --rc-color-primary-dark: var(--color-dark-medium);
-	 --rc-color-primary-light: var(--color-gray);
-	 --rc-color-primary-light-medium: var(--color-gray-medium);
 	 --rc-color-primary-lightest: var(--color-dark-medium); /* sidebar background light */
-	 --rc-color-content: var(--color-white);
-	 --rc-color-link-active: var(--rc-color-button-primary);
  
 	 /* Forms - Button */
-	 --button-disabled-background: var(--color-gray-light);
-	 --button-disabled-text-color: var(--color-white);
+	 --button-disabled-background: var(--color-dark-70);
+	 --button-disabled-text-color: var(--color-dark-80);
 	 --button-primary-background: var(--rc-color-button-primary);
 	 --button-primary-text-color: var(--color-white);
 	 --button-cancel-color: var(--rc-color-error);
@@ -99,11 +84,7 @@ body.dark-mode {
  
 	 /* Forms - Input */
 	 --input-text-color: var(--color-gray-lightest); /* Used in certain inputs and selects (with class .rc-input) */
-	 --input-placeholder-color: var(--color-gray-medium);
 	 --input-icon-color: var(--color-gray-lightest); /* used in inputs with .rc-input_wrapper */
-	 --input-border-color: var(--color-gray-light);
-	 --input-description-text-color: var(--color-gray);
-	 --input-error-color: var(--rc-color-error);
  
 	 /* Forms - popup list */
 	--popup-list-background: var(--color-dark); /* dark colors for popup lists */
@@ -112,28 +93,11 @@ body.dark-mode {
 	--popup-list-name-color: var(--color-white); /* dark colors for popup lists */
  
 	 /* Forms - tags */
-	 --tags-border-color: var(--color-gray-light);
 	 --tags-text-color: var(--color-white); /* tag (similar to chips) colors */
 	 --tags-background: var(--color-blue); /* tag (similar to chips) colors */
  
-	 /* Forms - select avatar */
-	 --select-avatar-upload-background: var(--color-gray-light);
-	 --select-avatar-upload-color: #2d343d;
- 
 	 /* Sidebar */
 	 --sidebar-background: var(--color-dark); /* override; otherwise uses --rc-color-primary */
-	 --sidebar-background-hover: var(--rc-color-primary-dark);
-	 --sidebar-background-light: var(--rc-color-primary-lightest);
-	 --sidebar-background-light-hover: var(--rc-color-primary-light); /* unused? */
- 
-	 /* Sidebar flex */
-	 --sidebar-flex-search-background: var(--color-white);
-	 --sidebar-flex-search-placeholder-color: var(--color-gray);
- 
-	 /* Sidebar Account */
-	 --sidebar-account-username-color: var(--color-white);
-	 --sidebar-account-username-color-darker: var(--color-dark);
-	 --sidebar-account-status-color: var(--color-gray);
  
 	 /* Sidebar Item */
 	 --sidebar-item-text-color: var(--rc-color-primary-light);
@@ -333,24 +297,20 @@ body.dark-mode .rc-modal__header {
 
 /* Buttons */
 
-body.dark-mode .rc-button {
-	border-color: var(--color-gray-medium);
-	color: var(--color-gray-medium);
+body.dark-mode .rc-button--outline {
+	border-color: var(--button-outline-color);
+	color: var(--button-outline-color);
 }
 
-body.dark-mode .rc-button:disabled {
-	border-color: var(--color-darkest);
-	color: var(--color-dark-70);
-	background-color: var(--color-dark-80);
+body.dark-mode .rc-button--outline.js-close {
+	border-color: var(--button-close-color);
+	color: var(--button-close-color);
 }
 
-body.dark-mode .rc-button--cancel.rc-button--outline {
-	color: var(--button-cancel-color);
+body.dark-mode .rc-button--cancel {
+	background-color: var(--button-cancel-color);
 	border-color: var(--button-cancel-color);
-}
-
-body.dark-mode .rc-button.rc-button--nude.js-close {
-	border: var(--button-border-width) solid var(--color-gray-medium);
+	color: var(--button-primary-text-color);
 }
 
 /* Contextual bar */

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -39,6 +39,7 @@ select {
 }
 
 
+
 /******************************************
  ************Transition Effect*************
  ******************************************/
@@ -83,6 +84,7 @@ select,
 .sidebar__footer {
 	transition: opacity 300ms linear, color 150ms, background-color 150ms, border-color 150ms;
 }
+
 
 
 /******************************************
@@ -155,6 +157,7 @@ body.dark-mode {
 	--alerts-background: #1d73f5;
 	--alerts-color: var(--color-white);
 }
+
 
 
 /******************************************
@@ -369,6 +372,7 @@ body.dark-mode .hljs-type,
 body.dark-mode .hljs-number {
 	color: var(--color-orange);
 }
+
 
 
 /**************Admin Panel******************/

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -67,10 +67,8 @@ body.dark-mode {
 	 Variables with comments beside them
 	 are variables changed in dark mode
 	************************************/
-	 /*
-	 * General Colors
-	 */
-
+	 
+	/* General Colors */
 	 --rc-color-button-primary: var(--color-blue);
 	 --rc-color-button-primary-light: var(--color-dark-blue);
 
@@ -90,9 +88,7 @@ body.dark-mode {
 	 --rc-color-content: var(--color-white);
 	 --rc-color-link-active: var(--rc-color-button-primary);
  
-	 /*
-	 * Forms - Button
-	 */
+	 /* Forms - Button */
 	 --button-disabled-background: var(--color-gray-light);
 	 --button-disabled-text-color: var(--color-white);
 	 --button-primary-background: var(--rc-color-button-primary);
@@ -101,9 +97,7 @@ body.dark-mode {
 	 --button-secondary-background: var(--color-gray-medium);
 	 --button-secondary-text-color: var(--color-dark-medium);
  
-	 /*
-	 * Forms - Input
-	 */
+	 /* Forms - Input */
 	 --input-text-color: var(--color-gray-lightest); /* Used in certain inputs and selects (with class .rc-input) */
 	 --input-placeholder-color: var(--color-gray-medium);
 	 --input-icon-color: var(--color-gray-lightest); /* used in inputs with .rc-input_wrapper */
@@ -111,51 +105,37 @@ body.dark-mode {
 	 --input-description-text-color: var(--color-gray);
 	 --input-error-color: var(--rc-color-error);
  
-	 /*
-	 * Forms - popup list
-	 */
+	 /* Forms - popup list */
 	--popup-list-background: var(--color-dark); /* dark colors for popup lists */
 	--popup-list-background-hover: var(--color-darkest); /* dark colors for popup lists */
 	--popup-list-selected-background: var(--color-dark); /* dark colors for popup lists */
 	--popup-list-name-color: var(--color-white); /* dark colors for popup lists */
  
-	 /*
-	 * Forms - tags
-	 */
+	 /* Forms - tags */
 	 --tags-border-color: var(--color-gray-light);
 	 --tags-text-color: var(--color-white); /* tag (similar to chips) colors */
 	 --tags-background: var(--color-blue); /* tag (similar to chips) colors */
  
-	 /*
-	 * Forms - select avatar
-	 */
+	 /* Forms - select avatar */
 	 --select-avatar-upload-background: var(--color-gray-light);
 	 --select-avatar-upload-color: #2d343d;
  
-	 /*
-	 * Sidebar
-	 */
+	 /* Sidebar */
 	 --sidebar-background: var(--color-dark); /* override; otherwise uses --rc-color-primary */
 	 --sidebar-background-hover: var(--rc-color-primary-dark);
 	 --sidebar-background-light: var(--rc-color-primary-lightest);
 	 --sidebar-background-light-hover: var(--rc-color-primary-light); /* unused? */
  
-	 /*
-	 * Sidebar flex
-	 */
+	 /* Sidebar flex */
 	 --sidebar-flex-search-background: var(--color-white);
 	 --sidebar-flex-search-placeholder-color: var(--color-gray);
  
-	 /*
-	 * Sidebar Account
-	 */
+	 /* Sidebar Account */
 	 --sidebar-account-username-color: var(--color-white);
 	 --sidebar-account-username-color-darker: var(--color-dark);
 	 --sidebar-account-status-color: var(--color-gray);
  
-	 /*
-	 * Sidebar Item
-	 */
+	 /* Sidebar Item */
 	 --sidebar-item-text-color: var(--rc-color-primary-light);
 	 --sidebar-item-hover-background: var(--rc-color-primary-darkest);
 	 --sidebar-item-active-background: var(--rc-color-primary-dark);
@@ -163,45 +143,31 @@ body.dark-mode {
 	 --sidebar-item-unread-color: var(--rc-color-content);
 	 --sidebar-item-popup-background: var(--rc-color-primary-dark);
  
-	 /*
-	 * Modal
-	 */
+	 /* Modal */
 	 --modal-back-button-color: var(--color-gray);
  
-	 /*
-	 * Modal - Create Channel
-	 */
+	 /* Modal - Create Channel */
 	 --create-channel-title-color: var(--color-darkest);
 	 --create-channel-description-color: var(--color-gray);
  
-	 /*
-	 * Toolbar
-	 */
+	 /* Toolbar */
 	 --toolbar-placeholder-color: var(--color-gray);
  
-	 /*
-	 * Rooms list
-	 */
+	 /* Rooms list */
 	 --rooms-list-title-color: var(--rc-color-primary-light);
 	 --rooms-list-empty-text-color: var(--color-gray);
  
-	 /*
-	 * Chip
-	 */
+	 /* Chip */
 	 --chip-background: var(--color-blue); /* background color of "chips" (small labels) */
  
-	 /*
-	 * Badge
-	 */
+	 /* Badge */
 	 --badge-text-color: var(--color-white);
 	 --badge-background: var(--rc-color-primary-dark);
 	 --badge-unread-background: var(--rc-color-primary-dark);
 	 --badge-user-mentions-background: var(--color-dark-blue);
 	 --badge-group-mentions-background: var(--rc-color-primary-dark);
  
-	 /*
-	 * Mention link
-	 */
+	 /* Mention link */
 	 --mention-link-background: var(--color-dark-medium); /* colors on username mention tag */
 	 --mention-link-text-color: var(--color-light-blue); /* colors on username mention tag */
 	 --mention-link-me-background: var(--color-dark-blue);
@@ -209,9 +175,7 @@ body.dark-mode {
 	 --mention-link-group-background: var(--rc-color-primary-dark);
 	 --mention-link-group-text-color: var(--color-white);
  
-	 /*
-	 * Message box
-	 */
+	 /* Message box */
 	 --message-box-placeholder-color: var(--color-gray-medium);
 	 --message-box-markdown-color: var(--color-gray);
 	 --message-box-markdown-hover-color: var(--color-dark);
@@ -221,9 +185,7 @@ body.dark-mode {
 	 --message-box-editing-color: #fff5df;
 	 --message-box-popover-title-text-color: var(--color-gray);
  
-	 /*
-	 * Header
-	 */
+	 /* Header */
 	 --header-toggle-favorite-color: var(--color-gray-medium);
 	 --header-toggle-favorite-star-color: var(--rc-color-alert-light);
 	 --header-toggle-encryption-off-color: var(--color-gray-medium);
@@ -232,28 +194,20 @@ body.dark-mode {
 	 --header-title-status-color: var(--color-gray);
 	 --header-background-color: var(--color-darkest); /* The main chat screen and header */
  
-	 /*
-	 * Flex nav
-	 */
+	 /* Flex nav */
 	 --flex-nav-background: var(--color-gray-lightest);
  
-	 /*
-	 * Popover
-	 */
+	 /* Popover */
 	 --popover-background: var(--color-dark);
 	 --popover-title-color: var(--color-white);
 	 --popover-item-color: var(--color-white);
 	 --popover-divider-color: var(--color-gray-light);
  
-	 /*
-	 * Tooltip
-	 */
+	 /* Tooltip */
 	 --tooltip-background: var(--color-darkest);
 	 --tooltip-text-color: var(--color-white);
  
-	 /*
-	 * alert
-	 */
+	 /* alert */
 	 --alerts-background: #1d73f5;
 	 --alerts-color: var(--color-white);
 }
@@ -391,9 +345,7 @@ body.dark-mode .rc-button:disabled {
 }
 
 body.dark-mode .rc-button--cancel.rc-button--outline {
-	color: #f5455c;
 	color: var(--button-cancel-color);
-	border-color: #f5455c;
 	border-color: var(--button-cancel-color);
 }
 

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -46,45 +46,7 @@ select {
 /******************************************
  ************Transition Effect*************
  ******************************************/
-input,
-textarea,
-select,
-.color-primary-font-color,
-.color-info-font-color,
-.background-info-font-color,
-.background-transparent-darker-before::before,
-.messages-box .message .body,
-.rc-header__name,
-.rc-header__wrap,
-.message .reactions>li,
-.message .title .is-bot,
-.message .title .role-tag,
-.message.new-day::before,
-.code-colors,
-.hljs-selector-id,
-.hljs-selector-tag,
-.hljs-attribute,
-.hljs-keyword,
-.hljs-title,
-.hljs-doctag,
-.hljs-string,
-.hljs-type,
-.hljs-literal,
-.hljs-number,
-.hljs-tag,
-.hljs-name,
-.hljs-attr,
-.hljs-template-variable,
-.hljs-variable,
-.rc-message-box__container,
-.messages-container .footer,
-.content-background-color,
-.message.new-day::after,
-.message .reactions>li,
-.border-component-color,
-.contextual-bar__header,
-.contextual-bar__content,
-.sidebar__footer {
+* {
 	transition: opacity 300ms linear, color 150ms, background-color 150ms, border-color 150ms;
 }
 

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -38,15 +38,49 @@ select {
 	}
 }
 
-.message.collapsed { 
-	display: none; 
-}
-
 
 /******************************************
  ************Transition Effect*************
  ******************************************/
-* {
+ input,
+ textarea,
+ select,
+ .color-primary-font-color,
+ .color-info-font-color,
+ .background-info-font-color,
+ .background-transparent-darker-before::before,
+ .messages-box .message .body, /* override for opacity transition */
+ .rc-header__name,
+ .rc-header__wrap,
+ .message .reactions>li,
+ .message .title .is-bot,
+ .message .title .role-tag,
+ .message.new-day::before,
+ .code-colors,
+ .hljs-selector-id,
+ .hljs-selector-tag,
+ .hljs-attribute,
+ .hljs-keyword,
+ .hljs-title,
+ .hljs-doctag,
+ .hljs-string,
+ .hljs-type,
+ .hljs-literal,
+ .hljs-number,
+ .hljs-tag,
+ .hljs-name,
+ .hljs-attr,
+ .hljs-template-variable,
+ .hljs-variable,
+ .rc-message-box__container,
+ .messages-container .footer,
+ .content-background-color,
+ .message.new-day::after,
+ .message .reactions>li,
+ .border-component-color,
+ .contextual-bar__header,
+ .contextual-bar__content,
+ .sidebar__footer {
 	transition: opacity 300ms linear, color 150ms, background-color 150ms, border-color 150ms;
 }
 

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -175,10 +175,6 @@ body.dark-mode .sidebar-item > a {
 	color: inherit;
 }
 
-body.dark-mode input {
-	color: var(--color-white);
-}
-
 body.dark-mode select option {
 	color: var(--color-dark);
 }
@@ -282,12 +278,14 @@ body.dark-mode .rc-button--outline {
 	color: var(--button-outline-color);
 }
 
-body.dark-mode .rc-button--outline.js-close {
+body.dark-mode .rc-button--outline.js-close,
+body.dark-mode .rc-button--nude.js-close {
 	border-color: var(--button-close-color);
 	color: var(--button-close-color);
 }
 
-body.dark-mode .rc-button--cancel {
+body.dark-mode .rc-button--cancel,
+body.dark-mode .rc-button--danger {
 	background-color: var(--button-cancel-color);
 	border-color: var(--button-cancel-color);
 	color: var(--button-primary-text-color);
@@ -423,11 +421,28 @@ body.dark-mode .rcx-accordion-item__bar:hover {
 	background-color: var(--color-dark-30);
 }
 
-body.dark-mode .rcx-box--text-style-h1,
-body.dark-mode .rcx-subtitle {
+body.dark-mode .rcx-box--text-style-h1, 
+body.dark-mode .rcx-subtitle, 
+body.dark-mode .rcx-box--text-color-default, 
+body.dark-mode .rcx-box--text-color-info {
 	color: var(--color-gray-lightest);
 }
 
 body.dark-mode .rcx-button--primary:disabled {
 	color: var(--color-gray);
+}
+
+body.dark-mode .permissions-manager .permission-grid .role-name {
+	background: var(--color-dark);
+}
+
+body.dark-mode .rc-apps-marketplace .rc-table-content tbody .rc-table-tr:not(.table-no-click):not(.table-no-pointer):hover, 
+body.dark-mode .rc-apps-section .rc-table-content tbody .rc-table-tr:not(.table-no-click):not(.table-no-pointer):hover {
+	background-color: var(--color-dark);
+}
+
+body.dark-mode .rc-apps-marketplace .rc-table-content .rc-table-info .rc-apps-categories .rc-apps-category, 
+body.dark-mode .rc-apps-section .rc-table-content .rc-table-info .rc-apps-categories .rc-apps-category {
+	color: var(--primary-font-color);
+    background-color: var(--color-dark-medium);
 }

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -38,6 +38,9 @@ select {
 	}
 }
 
+.message.collapsed { 
+	display: none; 
+}
 
 
 /******************************************
@@ -48,7 +51,7 @@ textarea,
 select,
 .color-primary-font-color,
 .color-info-font-color,
-.messages-box .message .body, /* override for opacity transition */
+.messages-box .message .body,
 .rc-header__name,
 .rc-header__wrap,
 .message .reactions>li,
@@ -84,36 +87,211 @@ select,
 }
 
 
-
 /******************************************
  *************Dark Mode Settings***********
  ******************************************/
 body.dark-mode {
-	--header-background-color: var(--color-darkest);
-	--header-title-username-color-darker: var(--color-gray-lightest);
-	--primary-font-color: var(--color-gray-lightest);
-	--info-font-color: var(--color-gray-light);
-	--message-box-typing-user-color: var(--color-gray-light);
+	/************************************
+	    These are custom variables
+	************************************/
+	--primary-font-color: var(--color-gray-lightest); /* default text color if not overriden */
+	--info-font-color: var(--color-gray-light); /* message sent time */ 
+	--message-box-background: hsla(0, 0, 100%, 0.1);
+ 
 
-	--rc-color-primary: var(--color-gray-lightest);
-	--rc-color-primary-lightest: var(--color-dark-medium);
-	--rc-color-alert-message-warning-background: hsl(352, 83%, 20%);
+	/************************************
+	 Variables with comments beside them
+	 are variables changed in dark mode
+	************************************/
+	 /*
+	 * General Colors
+	 */
 
-	--input-text-color: var(--color-gray-lightest);
-	--input-icon-color: var(--color-gray-lightest);
+	 --rc-color-button-primary: var(--color-blue);
+	 --rc-color-button-primary-light: var(--color-dark-blue);
 
-	--mention-link-text-color: var(--color-light-blue);
-	--mention-link-background: var(--color-dark-medium);
+	 --rc-color-alert-message-primary: var(--color-blue);
+	 --rc-color-alert-message-primary-background: #f1f6ff;
+	 --rc-color-alert-message-secondary: #7ca52b;
+	 --rc-color-alert-message-secondary-background: #fafff1;
+	 --rc-color-alert-message-warning: #d52d24;
+	 --rc-color-alert-message-warning-background: hsl(352, 83%, 20%); /* make alert warning messages have red backgrounds */
 
-	--chip-background: var(--color-blue);
-
-	--tags-background: var(--color-blue);
-	--tags-text-color: var(--color-white);
-
-	--popup-list-background: var(--color-dark);
-	--popup-list-selected-background: var(--color-dark);
-	--popup-list-name-color: var(--color-white);
-	--popup-list-background-hover: var(--color-darkest);
+	 --rc-color-primary: var(--color-gray-lightest); /* Sidebar background, tags text color */
+	 --rc-color-primary-darkest: var(--color-darkest);
+	 --rc-color-primary-dark: var(--color-dark-medium);
+	 --rc-color-primary-light: var(--color-gray);
+	 --rc-color-primary-light-medium: var(--color-gray-medium);
+	 --rc-color-primary-lightest: var(--color-dark-medium); /* sidebar background light */
+	 --rc-color-content: var(--color-white);
+	 --rc-color-link-active: var(--rc-color-button-primary);
+ 
+	 /*
+	 * Forms - Button
+	 */
+	 --button-disabled-background: var(--color-gray-light);
+	 --button-disabled-text-color: var(--color-white);
+	 --button-primary-background: var(--rc-color-button-primary);
+	 --button-primary-text-color: var(--color-white);
+	 --button-cancel-color: var(--rc-color-error);
+	 --button-secondary-background: var(--color-gray-medium);
+	 --button-secondary-text-color: var(--color-dark-medium);
+ 
+	 /*
+	 * Forms - Input
+	 */
+	 --input-text-color: var(--color-gray-lightest); /* Used in certain inputs and selects (with class .rc-input) */
+	 --input-placeholder-color: var(--color-gray-medium);
+	 --input-icon-color: var(--color-gray-lightest); /* used in inputs with .rc-input_wrapper */
+	 --input-border-color: var(--color-gray-light);
+	 --input-description-text-color: var(--color-gray);
+	 --input-error-color: var(--rc-color-error);
+ 
+	 /*
+	 * Forms - popup list
+	 */
+	--popup-list-background: var(--color-dark); /* dark colors for popup lists */
+	--popup-list-background-hover: var(--color-darkest); /* dark colors for popup lists */
+	--popup-list-selected-background: var(--color-dark); /* dark colors for popup lists */
+	--popup-list-name-color: var(--color-white); /* dark colors for popup lists */
+ 
+	 /*
+	 * Forms - tags
+	 */
+	 --tags-border-color: var(--color-gray-light);
+	 --tags-text-color: var(--color-white); /* tag (similar to chips) colors */
+	 --tags-background: var(--color-blue); /* tag (similar to chips) colors */
+ 
+	 /*
+	 * Forms - select avatar
+	 */
+	 --select-avatar-upload-background: var(--color-gray-light);
+	 --select-avatar-upload-color: #2d343d;
+ 
+	 /*
+	 * Sidebar
+	 */
+	 --sidebar-background: var(--color-dark); /* override; otherwise uses --rc-color-primary */
+	 --sidebar-background-hover: var(--rc-color-primary-dark);
+	 --sidebar-background-light: var(--rc-color-primary-lightest);
+	 --sidebar-background-light-hover: var(--rc-color-primary-light); /* unused? */
+ 
+	 /*
+	 * Sidebar flex
+	 */
+	 --sidebar-flex-search-background: var(--color-white);
+	 --sidebar-flex-search-placeholder-color: var(--color-gray);
+ 
+	 /*
+	 * Sidebar Account
+	 */
+	 --sidebar-account-username-color: var(--color-white);
+	 --sidebar-account-username-color-darker: var(--color-dark);
+	 --sidebar-account-status-color: var(--color-gray);
+ 
+	 /*
+	 * Sidebar Item
+	 */
+	 --sidebar-item-text-color: var(--rc-color-primary-light);
+	 --sidebar-item-hover-background: var(--rc-color-primary-darkest);
+	 --sidebar-item-active-background: var(--rc-color-primary-dark);
+	 --sidebar-item-active-color: var(--sidebar-item-text-color);
+	 --sidebar-item-unread-color: var(--rc-color-content);
+	 --sidebar-item-popup-background: var(--rc-color-primary-dark);
+ 
+	 /*
+	 * Modal
+	 */
+	 --modal-back-button-color: var(--color-gray);
+ 
+	 /*
+	 * Modal - Create Channel
+	 */
+	 --create-channel-title-color: var(--color-darkest);
+	 --create-channel-description-color: var(--color-gray);
+ 
+	 /*
+	 * Toolbar
+	 */
+	 --toolbar-placeholder-color: var(--color-gray);
+ 
+	 /*
+	 * Rooms list
+	 */
+	 --rooms-list-title-color: var(--rc-color-primary-light);
+	 --rooms-list-empty-text-color: var(--color-gray);
+ 
+	 /*
+	 * Chip
+	 */
+	 --chip-background: var(--color-blue); /* background color of "chips" (small labels) */
+ 
+	 /*
+	 * Badge
+	 */
+	 --badge-text-color: var(--color-white);
+	 --badge-background: var(--rc-color-primary-dark);
+	 --badge-unread-background: var(--rc-color-primary-dark);
+	 --badge-user-mentions-background: var(--color-dark-blue);
+	 --badge-group-mentions-background: var(--rc-color-primary-dark);
+ 
+	 /*
+	 * Mention link
+	 */
+	 --mention-link-background: var(--color-dark-medium); /* colors on username mention tag */
+	 --mention-link-text-color: var(--color-light-blue); /* colors on username mention tag */
+	 --mention-link-me-background: var(--color-dark-blue);
+	 --mention-link-me-text-color: var(--color-white);
+	 --mention-link-group-background: var(--rc-color-primary-dark);
+	 --mention-link-group-text-color: var(--color-white);
+ 
+	 /*
+	 * Message box
+	 */
+	 --message-box-placeholder-color: var(--color-gray-medium);
+	 --message-box-markdown-color: var(--color-gray);
+	 --message-box-markdown-hover-color: var(--color-dark);
+	 --message-box-user-typing-color: var(--color-gray-lightest); /* user typing color */
+	 --message-box-user-typing-user-color: var(--color-gray-lightest); /* user typing color */
+	 --message-box-container-border-color: var(--color-gray-medium);
+	 --message-box-editing-color: #fff5df;
+	 --message-box-popover-title-text-color: var(--color-gray);
+ 
+	 /*
+	 * Header
+	 */
+	 --header-toggle-favorite-color: var(--color-gray-medium);
+	 --header-toggle-favorite-star-color: var(--rc-color-alert-light);
+	 --header-toggle-encryption-off-color: var(--color-gray-medium);
+	 --header-toggle-encryption-on-color: var(--rc-color-alert-message-secondary);
+	 --header-title-username-color-darker: var(--color-gray-lightest); /* channel and user names in header */
+	 --header-title-status-color: var(--color-gray);
+	 --header-background-color: var(--color-darkest); /* The main chat screen and header */
+ 
+	 /*
+	 * Flex nav
+	 */
+	 --flex-nav-background: var(--color-gray-lightest);
+ 
+	 /*
+	 * Popover
+	 */
+	 --popover-background: var(--color-dark);
+	 --popover-title-color: var(--color-white);
+	 --popover-item-color: var(--color-white);
+	 --popover-divider-color: var(--color-gray-light);
+ 
+	 /*
+	 * Tooltip
+	 */
+	 --tooltip-background: var(--color-darkest);
+	 --tooltip-text-color: var(--color-white);
+ 
+	 /*
+	 * alert
+	 */
+	 --alerts-background: #1d73f5;
+	 --alerts-color: var(--color-white);
 }
 
 
@@ -135,14 +313,6 @@ body.dark-mode a {
 
 body.dark-mode .sidebar-item > a {
 	color: inherit;
-}
-
-body.dark-mode .emoji-picker {
-	background-color: var(--rc-color-primary-dark);
-}
-
-body.dark-mode .emoji-picker .filter-item.active {
-	border-color: hsl(203, 73%, 52%);
 }
 
 body.dark-mode .background-component-color {
@@ -195,6 +365,8 @@ body.dark-mode .error-border {
 	border-color: var(--color-dark-red);
 }
 
+/* Messages and message box */
+
 body.dark-mode .messages-container .footer,
 body.dark-mode .content-background-color {
 	background-color: var(--header-background-color);
@@ -206,25 +378,22 @@ body.dark-mode .border-component-color {
 	border-color: var(--rc-color-primary-lightest);
 }
 
-body.dark-mode .js-button[aria-label="Toggle Dark Mode"] {
-	filter: brightness(130%);
-}
-
 body.dark-mode .message .reactions>li,
 body.dark-mode .message .title .is-bot,
 body.dark-mode .message .title .role-tag,
 body.dark-mode .message.new-day::before {
-	background-color: hsl(219, 15%, 33%);
+	background-color: var(--rc-color-primary-dark);
+}
+
+body.dark-mode .message.editing {
+	background-color: var(--color-dark-blue);
 }
 
 body.dark-mode .rc-message-box__container {
-	background-color: hsla(0, 0, 100%, 0.1);
+	background-color: var(--message-box-background);
 }
 
-body.dark-mode .rc-message-box__typing,
-body.dark-mode .rc-message-box__typing-user {
-	color: var(--color-gray-lightest);
-}
+/* Modals */
 
 body.dark-mode .rc-modal,
 body.dark-mode .rc-modal__footer {
@@ -235,6 +404,8 @@ body.dark-mode .rc-modal__content,
 body.dark-mode .rc-modal__header {
 	color: var(--color-white);
 }
+
+/* Buttons */
 
 body.dark-mode .rc-button {
 	border-color: var(--color-gray-medium);
@@ -247,7 +418,6 @@ body.dark-mode .rc-button:disabled {
 	background-color: var(--color-dark-80);
 }
 
-/* Ensure that colors still come through on buttons in dark mode */
 body.dark-mode .rc-button--cancel.rc-button--outline {
 	color: #f5455c;
 	color: var(--button-cancel-color);
@@ -258,6 +428,8 @@ body.dark-mode .rc-button--cancel.rc-button--outline {
 body.dark-mode .rc-button.rc-button--nude.js-close {
 	border: var(--button-border-width) solid var(--color-gray-medium);
 }
+
+/* Contextual bar */
 
 body.dark-mode .contextual-bar {
 	background-color: var(--color-dark);
@@ -273,24 +445,15 @@ body.dark-mode .contextual-bar__content {
 	background-color: var(--color-dark);
 }
 
-body.dark-mode .message.editing {
-	background-color: var(--color-dark-blue);
-}
+/* Popovers */
 
 body.dark-mode .rc-popover__content {
-	background-color: var(--popover-item-color);
+	background-color: var(--popover-background);
 	box-shadow: 0px 0px 2px var(--color-dark-20);
-
 }
 
-body.dark-mode .rc-popover__item-text,
-body.dark-mode .rc-popover__icon,
-body.dark-mode .rc-popover__title{
-	color: var(--popover-background);
-}
-
-body.dark-mode .rc-popover__item-radio-label {
-	color: var(--color-white);
+body.dark-mode .emoji-picker .filter-item.active {
+	border-color: var(--color-light-blue);
 }
 
 body.dark-mode .rc-switch-double {
@@ -299,11 +462,6 @@ body.dark-mode .rc-switch-double {
 
 body.dark-mode .rc-header--room {
 	box-shadow: 0px 0px 3px var(--color-dark-medium);
-}
-
-body.dark-mode .rc-form-legend,
-body.dark-mode .rc-form-label {
-	color: var(--rc-color-primary-light);
 }
 
 body.dark-mode .room-leader:hover {

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -42,45 +42,45 @@ select {
 /******************************************
  ************Transition Effect*************
  ******************************************/
- input,
- textarea,
- select,
- .color-primary-font-color,
- .color-info-font-color,
- .background-info-font-color,
- .background-transparent-darker-before::before,
- .messages-box .message .body, /* override for opacity transition */
- .rc-header__name,
- .rc-header__wrap,
- .message .reactions>li,
- .message .title .is-bot,
- .message .title .role-tag,
- .message.new-day::before,
- .code-colors,
- .hljs-selector-id,
- .hljs-selector-tag,
- .hljs-attribute,
- .hljs-keyword,
- .hljs-title,
- .hljs-doctag,
- .hljs-string,
- .hljs-type,
- .hljs-literal,
- .hljs-number,
- .hljs-tag,
- .hljs-name,
- .hljs-attr,
- .hljs-template-variable,
- .hljs-variable,
- .rc-message-box__container,
- .messages-container .footer,
- .content-background-color,
- .message.new-day::after,
- .message .reactions>li,
- .border-component-color,
- .contextual-bar__header,
- .contextual-bar__content,
- .sidebar__footer {
+input,
+textarea,
+select,
+.color-primary-font-color,
+.color-info-font-color,
+.background-info-font-color,
+.background-transparent-darker-before::before,
+.messages-box .message .body, /* override for opacity transition */
+.rc-header__name,
+.rc-header__wrap,
+.message .reactions>li,
+.message .title .is-bot,
+.message .title .role-tag,
+.message.new-day::before,
+.code-colors,
+.hljs-selector-id,
+.hljs-selector-tag,
+.hljs-attribute,
+.hljs-keyword,
+.hljs-title,
+.hljs-doctag,
+.hljs-string,
+.hljs-type,
+.hljs-literal,
+.hljs-number,
+.hljs-tag,
+.hljs-name,
+.hljs-attr,
+.hljs-template-variable,
+.hljs-variable,
+.rc-message-box__container,
+.messages-container .footer,
+.content-background-color,
+.message.new-day::after,
+.message .reactions>li,
+.border-component-color,
+.contextual-bar__header,
+.contextual-bar__content,
+.sidebar__footer {
 	transition: opacity 300ms linear, color 150ms, background-color 150ms, border-color 150ms;
 }
 
@@ -155,7 +155,6 @@ body.dark-mode {
 	--alerts-background: #1d73f5;
 	--alerts-color: var(--color-white);
 }
-
 
 
 /******************************************


### PR DESCRIPTION
There were several goals in these changes:

1. Most importantly, switch to relying mainly on overriding Rocket.Chat CSS variables (defined [here](https://github.com/RocketChat/Rocket.Chat/blob/develop/app/theme/client/imports/general/variables.css)). Whenever overriding a variable was possible, I preferred that over writing a new CSS rule. More Rocket.Chat variables can be overridden as needed.
2. Remove redundant CSS rules (once the variables were added). This will probably be an ongoing task to make sure we're using as few rules as needed to accomplish the work.
3. Make dark mode easier for others to tweak. Rather than hunting down various rules, I wanted a few key variables to be defined which could a user could tweak to easily and consistently change the dark theme to suit their preferences. This has been partially accomplished and I'll keep working on this in the future.

For now I'm opening the PR because these changes should also fix https://github.com/pbaity/rocketchat-dark-mode/issues/13 and fix https://github.com/pbaity/rocketchat-dark-mode/issues/15. 