### PR TITLE
Clean up login page

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -268,11 +268,11 @@ body.dark-mode .rc-member-list__counter {
 }
 
 body.dark-mode .background-transparent-darker-before::before {
-    background-color: var(--color-dark-medium);
+	background-color: var(--color-dark-medium);
 }
 
 body.dark-mode .background-info-font-color {
-    background-color: var(--color-dark-medium);
+	background-color: var(--color-dark-medium);
 }
 
 body.dark-mode .rc-modal,
@@ -305,12 +305,12 @@ body.dark-mode .rc-button--danger {
 
 body.dark-mode .contextual-bar {
 	background-color: var(--color-dark);
-  	border-left: 2px solid var(--color-dark-medium);
+	border-left: 2px solid var(--color-dark-medium);
 }
 
 body.dark-mode .contextual-bar__header {
 	background-color: var(--color-dark);
-  	border-bottom: 1px solid var(--color-dark-medium);
+	border-bottom: 1px solid var(--color-dark-medium);
 }
 
 body.dark-mode .contextual-bar__content {
@@ -489,11 +489,30 @@ body.dark-mode .rc-apps-section .rc-table-content tbody .rc-table-tr:not(.table-
 body.dark-mode .rc-apps-marketplace .rc-table-content .rc-table-info .rc-apps-categories .rc-apps-category,
 body.dark-mode .rc-apps-section .rc-table-content .rc-table-info .rc-apps-categories .rc-apps-category {
 	color: var(--primary-font-color);
-    background-color: var(--color-dark-medium);
+	background-color: var(--color-dark-medium);
 }
 
-/**************Scrollbars******************/
 
+
+/**************Login Page******************/
+
+body.dark-mode section.full-page.color-tertiary-font-color {
+	background-color: var(--color-dark);
+}
+
+body.dark-mode .rc-button.rc-button--nude.forgot-password,
+body.dark-mode .rc-button.rc-button--nude.back-to-login,
+body.dark-mode .rc-button.rc-button--nude.register,
+body.dark-mode .register-link-replacement {
+	color: var(--color-white);
+}
+
+body.dark-mode #login-card {
+	background-color: var(--color-darkest);
+}
+
+
+/**************Scrollbars******************/
 body.dark-mode *::-webkit-scrollbar {
 	background-color: rgba(255, 255, 255, 0.05);
 }
@@ -520,5 +539,5 @@ body.dark-mode .rcx-box * .rcx-select {
 /* elevation tiles */
 body.dark-mode .rcx-tile--elevation-0, 
 body.dark-mode .rcx-tile--elevation-1 {
-    background-color: var(--color-dark-medium);
+	background-color: var(--color-dark-medium);
 }


### PR DESCRIPTION
closes #37 

I tried in https://github.com/pbaity/rocketchat-dark-mode/pull/36 to remove styles for the login page, but it looks like there have to be rules in order to keep the login page clean.

Without dark mode:
<img width="601" alt="image" src="https://user-images.githubusercontent.com/39106297/81507032-68f19a00-92c8-11ea-87a4-abd009aa015f.png">

With dark mode:
<img width="597" alt="image" src="https://user-images.githubusercontent.com/39106297/81507045-773fb600-92c8-11ea-86aa-9745dff3456d.png">