### PR TITLE
Fix hover color

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -250,6 +250,11 @@ body.dark-mode .message.new-day::before {
 	background-color: var(--rc-color-primary-dark);
 }
 
+body.dark-mode .message.active,
+body.dark-mode .message:hover {
+    background-color: var(--color-dark-medium);
+}
+
 body.dark-mode .message.editing {
 	background-color: var(--color-dark-blue);
 }


### PR DESCRIPTION
closes #41 

I was torn whether to use `--color-dark-medium` or `--color-dark`. The former is what @VVvKamper suggested in the issue above, but almost seemed too light. The latter is darker but also matches the sidebar color, which looks a little odd. I'll set it to `--color-dark-medium` since the suggestion in the issue was well-received, and if enough people complain we can change it 🙂 