### PR TITLE
Apply dark mode to header's bottom border

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -356,7 +356,7 @@ body.dark-mode .emoji-picker .filter-item.active {
 }
 
 body.dark-mode .rc-header--room {
-	box-shadow: 0px 0px 3px var(--color-dark-medium);
+	border-bottom: 2px solid var(--color-dark);
 }
 
 body.dark-mode .room-leader:hover {

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -356,7 +356,7 @@ body.dark-mode .emoji-picker .filter-item.active {
 }
 
 body.dark-mode .rc-header--room {
-	border-bottom: 2px solid var(--color-dark);
+	border-bottom: 2px solid var(--color-dark-medium);
 }
 
 body.dark-mode .room-leader:hover {


### PR DESCRIPTION
In 3.4.2, the room header is styled with a bottom border rather than with box-shadow as in previous versions, resulting in this:

<img width="165" alt="image" src="https://user-images.githubusercontent.com/39106297/87940197-39e56a80-ca67-11ea-8114-e9c48e01ee39.png">

Applying dark mode by overwriting the `border-bottom` rule:

<img width="166" alt="image" src="https://user-images.githubusercontent.com/39106297/87940562-c7c15580-ca67-11ea-872a-cddb179c0728.png">

The color (`--color-dark-medium`) is the same as was used previously.