### PR TITLE
Update hover color; fix message actions

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -5,7 +5,7 @@
 :root {
 	--primary-font-color: #444;
 	--info-font-color: #a0a0a0;
-	--rc-status-online: #43b581;
+	--color-darker: #272c33;
 }
 
 /* Reset global font color so that it's changable more easily */
@@ -253,7 +253,7 @@ body.dark-mode .message.new-day::before {
 
 body.dark-mode .message.active,
 body.dark-mode .message:hover {
-    background-color: var(--color-dark-medium);
+    background-color: var(--color-darker);
 }
 
 body.dark-mode .message.editing {
@@ -270,7 +270,14 @@ body.dark-mode .rc-old .rc-message-box .reply-preview {
 
 body.dark-mode .message-actions,
 body.dark-mode .rc-member-list__counter {
-	color: var(--color-gray);
+	color: var(--color-gray-light);
+	background-color: var(--color-darkest);
+	border-color: var(--color-dark);
+}
+
+body.dark-mode .message-actions__button:hover,
+body.dark-mode .message-actions__menu:hover {
+	background-color: var(--color-dark-light);
 }
 
 body.dark-mode .background-transparent-darker-before::before {

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -277,7 +277,7 @@ body.dark-mode .rc-member-list__counter {
 
 body.dark-mode .message-actions__button:hover,
 body.dark-mode .message-actions__menu:hover {
-	background-color: var(--color-dark-light);
+	background-color: var(--color-dark);
 }
 
 body.dark-mode .background-transparent-darker-before::before {


### PR DESCRIPTION
fixes #52 

The new color variable `--color-darker` is the calculated middle point between the colors `--color-dark` and `--color-darkest` and helps message hover not be so bright. I think this complements the look of the message actions well too:

<img width="179" alt="image" src="https://user-images.githubusercontent.com/39106297/90274816-37402000-de2f-11ea-8e11-52d6186605a8.png">

And it forms a nice inverse of what it looks like without dark mode:

<img width="166" alt="image" src="https://user-images.githubusercontent.com/39106297/90261217-ab23fd80-de1a-11ea-948e-54158e5bfd34.png">
