### PR TITLE
Update terms of service page colors

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -609,6 +609,10 @@ body.dark-mode .setting-action {
 
 /**************Login Page******************/
 
+body.dark-mode main#rocket-chat {
+	background-color: var(--color-dark);
+}
+
 body.dark-mode section.full-page.color-tertiary-font-color {
 	background-color: var(--color-dark);
 }
@@ -616,6 +620,7 @@ body.dark-mode section.full-page.color-tertiary-font-color {
 body.dark-mode .rc-button.rc-button--nude.forgot-password,
 body.dark-mode .rc-button.rc-button--nude.back-to-login,
 body.dark-mode .rc-button.rc-button--nude.register,
+body.dark-mode .rc-button.rc-button--nude i.icon-cancel,
 body.dark-mode .register-link-replacement {
 	color: var(--color-white);
 }


### PR DESCRIPTION
fixes #49 

These rules apply to the Terms of Service, Privacy Policy, and Legal Notice pages on the login screen. Now they look like this:

<img width="530" alt="image" src="https://user-images.githubusercontent.com/39106297/90301355-5c538380-de6d-11ea-8664-4205259c4a47.png">
