### PR TITLE
Fix modal backdrop transparency

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -558,6 +558,10 @@ body.dark-mode .rcx-box {
 	background-color: var(--color-dark) !important;
 }
 
+body.dark-mode .rcx-modal__backdrop {
+	background-color: transparent !important;
+}
+
 body.dark-mode .rcx-table__cell--align-start {
     color: var(--info-font-color) !important;
 	background-color: var(--color-dark-medium) !important;


### PR DESCRIPTION
## Context

The new User Profile modal has a transparent backdrop.

Before `v3.5.1`, this configuration was needed:

![image](https://user-images.githubusercontent.com/19298197/90340545-55448680-dfcf-11ea-86cb-ba824bd9c24d.png)

The new default seems to open the User Profile modal anyway.
> Settings > Layout > User Interface

## Screenshots

<details>
<summary>Before</summary>

![image](https://user-images.githubusercontent.com/19298197/90340386-2679e080-dfce-11ea-89aa-80a256ac9d05.png)

</details>

<details>
<summary>After</summary>

![image](https://user-images.githubusercontent.com/19298197/90340345-e0bd1800-dfcd-11ea-862f-4479439c074e.png)

</details>