### PR TITLE
Add rc-old code inline dark mode

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -377,7 +377,8 @@ body.dark-mode .message-popup-title {
 
 /**************Code Highlights*****************/
 
-body.dark-mode .code-colors {
+body.dark-mode .code-colors,
+body.dark-mode .rc-old code.inline {
 	background: var(--color-dark-100);
 	color: var(--color-gray-light);
 }


### PR DESCRIPTION
## Context

This PR adds contrast to `.rc-old code.inline` nodes.
Where to find them:

`Administration > Integrations > "Click any integration"`

## Discussion

I added the `.rc-old` class to narrow the scope, `code.inline` seemed too broad.
Suggestions are welcome!

## Screenshots

<details>
<summary>Before</summary>

![image](https://user-images.githubusercontent.com/19298197/90637197-15191a00-e202-11ea-9b79-fdf5f6014d10.png)

</details>

<details>
<summary>After</summary>

![image](https://user-images.githubusercontent.com/19298197/90637225-1cd8be80-e202-11ea-993b-a2e6ccc0d05f.png)

</details>