### PR TITLE
Fix message highlight animation

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -41,7 +41,7 @@ input, select, textarea {
 
 @keyframes highlight {
 	from {
-		background-color: hsl(25, 70%, 45%);
+		background-color: hsl(216, 92%, 54%);
 	}
 }
 

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -39,7 +39,11 @@ input, select, textarea {
 	}
 }
 
-
+@keyframes highlight {
+	from {
+		background-color: hsl(25, 70%, 45%);
+	}
+}
 
 /******************************************
  ************Transition Effect*************


### PR DESCRIPTION
## Context

This PR fixes contrast in `animation: highlight`.
To reproduce, click on a message sent in a thread (See recordings for more details).

## Discussion

:art: Color suggestions are welcome!

## Recordings

<details>
<summary>Before</summary>

![before](https://user-images.githubusercontent.com/19298197/90672908-43601f00-e22d-11ea-96c9-3234f28bb8e6.gif)

</details>

<details>
<summary>After</summary>

![after](https://user-images.githubusercontent.com/19298197/90672922-49560000-e22d-11ea-9c08-1b632e56b62a.gif)

</details>