### PR TITLE
Fix background color of the "Unread Messages" label

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -271,6 +271,10 @@ body.dark-mode .message.editing {
 	background-color: var(--color-dark-blue);
 }
 
+body.dark-mode .message.first-unread .body:after {
+	background-color: var(--header-background-color);
+}
+
 body.dark-mode .rc-message-box__container {
 	background-color: var(--message-box-background);
 }


### PR DESCRIPTION
Make it use the header-background-color variable which is also used for the entire chat window.

Before, after.
![image](https://user-images.githubusercontent.com/2890874/94943525-20858380-04d8-11eb-94d6-27be321f9d52.png)
