### PR TITLE
Unread message indicator of Threads is invisible

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -681,6 +681,6 @@ body.dark-mode .rcx-box--text-color-default,
 body.dark-mode .rcx-box--text-color-info {
     color: var(--color-dark);
 }
-body.dark-mode .rcx-\@tmocsy { 
+body.dark-mode div.rcx-box.rcx-box--full[aria-label="Unread"] { 
 	background-color: #1d74f5 !important;
 }

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -681,3 +681,6 @@ body.dark-mode .rcx-box--text-color-default,
 body.dark-mode .rcx-box--text-color-info {
     color: var(--color-dark);
 }
+body.dark-mode .rcx-\@tmocsy { 
+	background-color: #1d74f5 !important;
+}


### PR DESCRIPTION
Closes #69
I think, that issue was in

```
body.dark-mode .rcx-box {
	background-color: var(--color-dark) !important;
}
```
In !important; line

Did try to delete !Important in that line https://github.com/pbaity/rocketchat-dark-mode/blob/master/dark-mode.css#L574 and it's work too, but I don't know what else could be affected.
So I added problem element with !Important
Now unread indicator is visible in dark mode

![image](https://user-images.githubusercontent.com/4023037/95681898-84acf380-0c0c-11eb-9c8d-50091a45f813.png)