### PR TITLE
Fix Rocket Chat scrollbar thumb invisible

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -8,6 +8,10 @@
 	--color-darker: #272c33;
 }
 
+*::-webkit-scrollbar-thumb {
+	background-color: rgba(255, 255, 255, 0.15);
+}
+
 /* Reset global font color so that it's changable more easily */
 .color-primary-font-color, textarea {
 	color: var(--primary-font-color);

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -6,6 +6,7 @@
 	--primary-font-color: #444;
 	--info-font-color: #a0a0a0;
 	--color-darker: #272c33;
+	--custom-scrollbar-color: background-color: rgba(255, 255, 255, 0.15);
 }
 
 /* Reset global font color so that it's changable more easily */
@@ -168,9 +169,6 @@ body.dark-mode {
 
 	--message-box-editing-color: var(--rc-color-alert-message-warning-background);
 	--rc-color-alert: var(--color-dark-red);
-
-	/* Scrollbar Thumb */
-	--custom-scrollbar-color: background-color: rgba(255, 255, 255, 0.15);
 }
 
 

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -8,10 +8,6 @@
 	--color-darker: #272c33;
 }
 
-*::-webkit-scrollbar-thumb {
-	background-color: rgba(255, 255, 255, 0.15);
-}
-
 /* Reset global font color so that it's changable more easily */
 .color-primary-font-color, textarea {
 	color: var(--primary-font-color);
@@ -172,6 +168,9 @@ body.dark-mode {
 
 	--message-box-editing-color: var(--rc-color-alert-message-warning-background);
 	--rc-color-alert: var(--color-dark-red);
+
+	/* Scrollbar Thumb */
+	--custom-scrollbar-color: background-color: rgba(255, 255, 255, 0.15);
 }
 
 

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -681,3 +681,6 @@ body.dark-mode .rcx-box--text-color-default,
 body.dark-mode .rcx-box--text-color-info {
     color: var(--color-dark);
 }
+body.dark-mode .rcx-\@tmocsy { 
+	background-color: #1d74f5 !important;
+}

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -663,7 +663,7 @@ body.dark-mode *::-webkit-scrollbar {
 	background-color: rgba(255, 255, 255, 0.05);
 }
 
-body.dark-mode *::-webkit-scrollbar-thumb {
+*::-webkit-scrollbar-thumb {
 	background-color: rgba(255, 255, 255, 0.15);
 }
 
@@ -681,7 +681,4 @@ body.dark-mode .rcx-subtitle,
 body.dark-mode .rcx-box--text-color-default, 
 body.dark-mode .rcx-box--text-color-info {
     color: var(--color-dark);
-}
-body.dark-mode .rcx-\@tmocsy { 
-	background-color: #1d74f5 !important;
 }


### PR DESCRIPTION
closes #74
Set color to thump
![image](https://user-images.githubusercontent.com/4023037/95734959-63044880-0cae-11eb-893d-8ce72ac3be19.png)
