### PR TITLE
Add rules to style markdown tables

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -295,6 +295,18 @@ body.dark-mode .message-actions__menu:hover {
 	background-color: var(--color-dark);
 }
 
+body.dark-mode .message .body > table thead tr {
+    background-color: var(--color-darkest);
+}
+
+body.dark-mode .message .body > table tr {
+    background-color: var(--color-dark-medium);
+}
+
+body.dark-mode .message .body > table tr:nth-child(2n) {
+    background-color: var(--color-dark);
+}
+
 body.dark-mode .background-transparent-darker-before::before {
 	background-color: var(--color-dark-medium);
 }


### PR DESCRIPTION
closes #77 

Makes tables look like this:
![image](https://user-images.githubusercontent.com/39106297/96151072-05a00f80-0ed9-11eb-8b3e-22bef20ad5fb.png)