### PR TITLE
Style scroll bars to avoid visual clash (especially on Firefox)

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -690,9 +690,36 @@ body.dark-mode .rc-modal-wrapper > dialog > div {
 	background-color: var(--header-background-color);
 }
 
-body.dark-mode .rcx-box--text-style-h1, 
-body.dark-mode .rcx-subtitle, 
-body.dark-mode .rcx-box--text-color-default, 
+body.dark-mode .rcx-box--text-style-h1,
+body.dark-mode .rcx-subtitle,
+body.dark-mode .rcx-box--text-color-default,
 body.dark-mode .rcx-box--text-color-info {
     color: var(--color-dark);
+}
+
+/* Style the browser scroll bars to avoid visually clashing with the rest of Rocket.Chat in dark mode. */
+
+body.dark-mode * {
+	scrollbar-color: #777 transparent;
+}
+
+body.dark-mode *::-webkit-scrollbar {
+	width: .75rem;
+}
+
+body.dark-mode *::-webkit-scrollbar-track {
+	background-color: transparent;
+}
+
+body.dark-mode *::-webkit-scrollbar-thumb {
+	background-color: #777;
+}
+
+/* Firefox does the dimming on hover automatically. We emulate it for Webkit-based browsers. */
+body.dark-mode *::-webkit-scrollbar-thumb:hover {
+	background-color: #666;
+}
+
+body.dark-mode *::-webkit-scrollbar-thumb:active {
+	background-color: #444;
 }


### PR DESCRIPTION
I had to do this to make scroll bars blend in nicely with the rest of Rocket.Chat on Firefox 83 (Linux).

## Preview

### Before

![Light scrollbar](https://user-images.githubusercontent.com/180032/104136797-a9923d80-5398-11eb-8b98-e7a4e50dce4d.png)

### After

![Dark scrollbar](https://user-images.githubusercontent.com/180032/104136788-9a12f480-5398-11eb-9076-171bb464e074.png)