### PR TITLE
Highlight substrings in code

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -435,7 +435,8 @@ body.dark-mode .hljs-name {
 	color: var(--color-light-blue);
 }
 
-body.dark-mode .hljs-selector-tag {
+body.dark-mode .hljs-selector-tag,
+body.dark-mode .hljs-subst {
 	color: var(--color-green);
 }
 


### PR DESCRIPTION
Highlight substrings with a visible color. Normally they're highlighted with the same color as `.hljs-selector-tag`, so I just added them to the rule for that class. 

Before:
![image](https://user-images.githubusercontent.com/39106297/104229361-2c0f1180-541a-11eb-8e7b-5153ac18bc7f.png)

After:
![image](https://user-images.githubusercontent.com/39106297/104229272-0d107f80-541a-11eb-9eaa-16121ac9f203.png)

If anyone feels strongly that this is a terrible color choice, just let me know. I'll let this hang out for a day or two to give the community a chance to veto.
