### PR TITLE
Fix blue mention link text

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -183,6 +183,14 @@ body.dark-mode .main-content a {
 	color: var(--color-light-blue);
 }
 
+body.dark-mode .mention-link--group {
+	color: var(--mention-link-group-text-color) !important;
+}
+
+body.dark-mode .mention-link--me {
+	color: var(--mention-link-me-text-color) !important;
+}
+
 body.dark-mode select {
 	background-color: var(--color-dark);
 }


### PR DESCRIPTION
closes #89

The text of group and me mentions was blue because of the rule styling all links in the main chat. Adding these two rules (keeping them separate so they can use their own color variables) overrides the link rule and the text appears white again.

Before:
<img width="218" alt="image" src="https://user-images.githubusercontent.com/39106297/99984006-912f7a80-2d7a-11eb-8541-623e6f3d90aa.png">

After:
![image](https://user-images.githubusercontent.com/39106297/104230954-3af6c380-541c-11eb-89b0-faa6af9a6342.png)
