### PR TITLE
Dark Theme improvement & fixes for RocketChat 3.11.0

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -373,6 +373,20 @@ body.dark-mode .rc-member-list__counter {
 	background-color: var(--color-dark);
 }
 
+/***** Buttons  *****/
+
+/* Top-right buttons */
+body.dark-mode .rcx-button--tiny-square.rcx-button:not(.rcx-button--ghost), /* Selected button */
+/* body.dark-mode .rcx-button--tiny-square.rcx-button--ghost.hover, */
+/* body.dark-mode .rcx-button--tiny-square.rcx-button--ghost.is-hovered, */
+body.dark-mode .rcx-button--tiny-square.rcx-button--ghost:hover,
+/* body.dark-mode .rcx-button--tiny-square.rcx-button.hover,  */
+/* body.dark-mode .rcx-button--tiny-square.rcx-button.is-hovered,  */
+body.dark-mode .rcx-button--tiny-square.rcx-button:hover {
+	border-color: transparent !important;
+	background-color: var(--color-dark) !important;
+}
+
 /***** Right sidebar *****/
 
 body.dark-mode .rcx-vertical-bar,

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -785,3 +785,8 @@ body.dark-mode .rcx-sidebar-item--highlighted {
 body.dark-mode .rcx-sidebar-item__container span.rcx-box.rcx-box--full.rcx-badge {
 	background-color: var(--rc-color-alert);
 } */
+
+/* This CSS block is used to counter RocketChat's bug which crop the end of custom CSS. */
+.dummy-entry {
+    color: whitesmoke;
+}

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -373,7 +373,33 @@ body.dark-mode .rc-member-list__counter {
 	background-color: var(--color-dark);
 }
 
-/***** Buttons  *****/
+/**** Select / Dropdowns ****/
+
+body.dark-mode .rcx-select {
+    background-color: var(--rc-color-primary-darkest) !important;
+}
+
+body.dark-mode .rcx-options > .rcx-tile {
+    background-color: var(--rc-color-primary-darkest) !important;
+}
+
+body.dark-mode .rcx-options .rcx-option {
+	background-color: var(--rc-color-primary-darkest) !important;
+	color: var(--color-white) !important;
+}
+
+body.dark-mode .rc-popover__content .rcx-option:hover,
+body.dark-mode .rcx-options .rcx-option--focus, 
+body.dark-mode .rcx-options .rcx-option--selected {
+    background-color: var(--color-dark-light) !important;
+}
+
+body.dark-mode .rcx-options .rcx-option:hover,
+body.dark-mode .rcx-options .rcx-option--selected:hover {
+	background-color: var(--color-dark) !important;
+}
+
+/***** Buttons *****/
 
 /* Top-right buttons */
 body.dark-mode .rcx-button--tiny-square.rcx-button:not(.rcx-button--ghost), /* Selected button */
@@ -388,6 +414,8 @@ body.dark-mode .rcx-button--tiny-square.rcx-button:hover {
 }
 
 /***** Right sidebar *****/
+
+/* TODO : switch toggle */
 
 body.dark-mode .rcx-vertical-bar,
 body.dark-mode .rcx-vertical-bar .rcx-button {

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -583,6 +583,19 @@ body.dark-mode .js-logout {
 	color: var(--primary-font-color);
 }
 
+body.dark-mode .rcx-css-1org57t ~ .rcx-button { /* Button (with cross icon) button to close admin panel */
+    color: var(--color-dark) !important;
+}
+
+/*body.dark-mode .simplebar-content > .rcx-box => will also modify sidebar background */
+body.dark-mode .simplebar-content > .rcx-css-fr02gd { /* main content */
+    background-color: var(--color-dark);
+}
+
+body.dark-mode .rcx-select__item {
+	color: var(--primary-font-color) !important;
+}
+
 body.dark-mode .sidebar-flex__header {
 	background-color: var(--color-dark);
 }
@@ -607,6 +620,7 @@ body.dark-mode .rcx-input-box__wrapper {
 
 body.dark-mode .rcx-box * .rcx-input-box {
 	background-color: var(--color-dark);
+	color: var(--rc-color-primary);
 }
 
 body.dark-mode .rcx-table__cell {

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -401,29 +401,47 @@ body.dark-mode .rcx-options .rcx-option--selected:hover {
 
 /***** Buttons *****/
 
-/* Top-right buttons */
-body.dark-mode .rcx-button--tiny-square.rcx-button:not(.rcx-button--ghost), /* Selected button */
-/* body.dark-mode .rcx-button--tiny-square.rcx-button--ghost.hover, */
-/* body.dark-mode .rcx-button--tiny-square.rcx-button--ghost.is-hovered, */
-body.dark-mode .rcx-button--tiny-square.rcx-button--ghost:hover,
-/* body.dark-mode .rcx-button--tiny-square.rcx-button.hover,  */
-/* body.dark-mode .rcx-button--tiny-square.rcx-button.is-hovered,  */
-body.dark-mode .rcx-button--tiny-square.rcx-button:hover {
+/* Top-right and right sidebar buttons */
+body.dark-mode /*.rcx-button--tiny-square*/ *:is(.rcx-room-header, .rcx-vertical-bar) .rcx-button:not(.rcx-button--ghost), /* Selected buttons */
+body.dark-mode /*.rcx-button--tiny-square*/ *:is(.rcx-room-header, .rcx-vertical-bar) *:is(.rcx-button--ghost, .rcx-button:hover):hover { /* Hovered buttons */
 	border-color: transparent !important;
 	background-color: var(--color-dark) !important;
+}
+
+/* body.dark-mode .main-content .rcx-button {
+	background-color: var(--color-dark-medium);
+} */
+
+body.dark-mode .rcx-button {
+    color: var(--info-font-color);
+}
+
+body.dark-mode .rcx-button--primary {
+	color: var(--info-font-color);
+	background-color: #095ad2
+}
+
+body.dark-mode .rcx-button--primary:disabled {
+	color: var(--color-gray);
+}
+
+body.dark-mode .rcx-button--danger {
+	color: var(--rcx-button-colors-secondary-danger-color,var(--rcx-color-danger-500,#f5455c));
 }
 
 /***** Right sidebar *****/
 
 /* TODO : switch toggle */
 
-body.dark-mode .rcx-vertical-bar,
-body.dark-mode .rcx-vertical-bar .rcx-button {
+body.dark-mode .rcx-vertical-bar {
 	background-color: var(--rc-color-primary-background) !important;
 }
 
-body.dark-mode .rcx-vertical-bar .rcx-button:hover {
-    background-color: var(--rc-color-primary-dark) !important;
+body.dark-mode .rcx-css-136xdpx:hover, /* Thread list item */
+body.dark-mode .rcx-css-136xdpx:focus, 
+body.dark-mode .rcx-css-1es44sn:hover, /* Files list item */
+body.dark-mode .rcx-css-1es44sn:focus {
+    background-color: var(--rc-color-primary-dark);
 }
 
 /* Targets unread message indicator in threads panel. */
@@ -616,10 +634,6 @@ body.dark-mode .rcx-table__cell {
 	color: var(--color-gray-lightest);
 }
 
-body.dark-mode .rcx-button--primary:disabled {
-	color: var(--color-gray);
-}
-
 body.dark-mode .permissions-manager .permission-grid .role-name {
 	background: var(--color-dark);
 }
@@ -654,10 +668,15 @@ body.dark-mode .rcx-table__cell--align-end {
 	background-color: var(--color-dark-medium) !important;
 }
 
-body.dark-mode .main-content .rcx-box {
+/* Apply info (white) font *everywhere* */
+body.dark-mode *:is(.rcx-room-header, .rcx-vertical-bar) .rcx-box:not(.rcx-button) {
     color: var(--info-font-color) !important;
-	/* background-color: var(--color-dark) !important; */
 }
+
+/* body.dark-mode .main-content .rcx-box {
+    color: var(--info-font-color) !important;
+	background-color: var(--color-dark) !important;
+} */
 
 body.dark-mode .rcx-modal__backdrop {
 	background-color: transparent !important;
@@ -666,15 +685,6 @@ body.dark-mode .rcx-modal__backdrop {
 body.dark-mode .rcx-table__cell--align-start {
     color: var(--info-font-color) !important;
 	background-color: var(--color-dark-medium) !important;
-}
-
-body.dark-mode .main-content .rcx-button {
-	/* background-color: var(--color-dark-medium); */
-}
-
-body.dark-mode .rcx-button--primary {
-	color: var(--info-font-color);
-	background-color: #095ad2
 }
 
 body.dark-mode  .rcx-field__description code {

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -383,13 +383,14 @@ body.dark-mode .rcx-options > .rcx-tile {
     background-color: var(--rc-color-primary-darkest) !important;
 }
 
-body.dark-mode .rcx-options .rcx-option {
+body.dark-mode .rcx-options .rcx-option,
+body.dark-mode .rcx-options .rcx-option--focus /* Temporary fix while focus is not refreshed */ {
 	background-color: var(--rc-color-primary-darkest) !important;
 	color: var(--color-white) !important;
 }
 
 body.dark-mode .rc-popover__content .rcx-option:hover,
-body.dark-mode .rcx-options .rcx-option--focus, 
+/* body.dark-mode .rcx-options .rcx-option--focus, */ /* Temporary fix while focus is not refreshed */
 body.dark-mode .rcx-options .rcx-option--selected {
     background-color: var(--color-dark-light) !important;
 }

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -786,9 +786,11 @@ body.dark-mode .rcx-box--text-color-info {
 
 /* Style the browser scroll bars to avoid visually clashing with the rest of Rocket.Chat in dark mode. */
 
+/*
 body.dark-mode * {
 	scrollbar-color: #777 transparent;
 }
+*/
 
 body.dark-mode *::-webkit-scrollbar {
 	width: .75rem;

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -739,7 +739,7 @@ body.dark-mode *::-webkit-scrollbar-thumb:active {
 
 /***** Changes for 3.9.1 *****/
 
-aside.sidebar--main .rcx-sidebar-topbar .rcx-button--small-square {
+/* aside.sidebar--main .rcx-sidebar-topbar .rcx-button--small-square {
     width: 1.35rem;
 }
 
@@ -784,4 +784,4 @@ body.dark-mode .rcx-sidebar-item--highlighted {
 
 body.dark-mode .rcx-sidebar-item__container span.rcx-box.rcx-box--full.rcx-badge {
 	background-color: var(--rc-color-alert);
-}
+} */

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -326,14 +326,22 @@ body.dark-mode .background-transparent-darker-before::before {
 /*body.dark-mode .background-info-font-color {
 	background-color: var(--color-dark-medium);
 }*/
+body.dark-mode .rcx-modal__inner,
+body.dark-mode .rcx-modal__footer {
+	background: var(--color-dark);
+}
 
-body.dark-mode .rc-modal,
-body.dark-mode .rc-modal__footer {
+body.dark-mode .rc-modal__footer,
+body.dark-mode .rc-modal {
 	background: var(--color-darkest);
 }
 
 body.dark-mode .rc-modal__content,
-body.dark-mode .rc-modal__header {
+body.dark-mode .rc-modal__header,
+body.dark-mode .rcx-modal__content,
+body.dark-mode .rcx-modal__inner,
+body.dark-mode .rcx-modal__header,
+body.dark-mode .rcx-modal__title {
 	color: var(--color-white);
 }
 
@@ -419,6 +427,10 @@ body.dark-mode .main-content .rcx-button--square:is(.rcx-button--ghost, .rcx-but
 
 body.dark-mode .rcx-button {
     color: var(--info-font-color);
+}
+
+body.dark-mode .rcx-button--ghost:hover {
+	color: var(--color-dark) !important;
 }
 
 body.dark-mode .rcx-button--primary {
@@ -685,9 +697,9 @@ body.dark-mode .rcx-vertical-bar .rcx-box:not(.rcx-button-group):not(.rcx-button
 	background-color: var(--color-dark) !important;
 } */
 
-body.dark-mode .rcx-modal__backdrop {
+/* body.dark-mode .rcx-modal__backdrop {
 	background-color: transparent !important;
-}
+} */
 
 body.dark-mode .rcx-table__cell--align-start {
     color: var(--info-font-color) !important;

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -183,6 +183,10 @@ body.dark-mode .main-content a {
 	color: var(--color-light-blue);
 }
 
+body.dark-mode .main-content .messages-box .wrapper {
+	background-color: var(--color-darkest);
+}
+
 body.dark-mode .mention-link--group {
 	color: var(--mention-link-group-text-color) !important;
 }
@@ -599,7 +603,7 @@ body.dark-mode .rcx-table__cell--align-end {
 
 body.dark-mode .main-content .rcx-box {
     color: var(--info-font-color) !important;
-	background-color: var(--color-dark) !important;
+	/* background-color: var(--color-dark) !important; */
 }
 
 body.dark-mode .rcx-modal__backdrop {
@@ -612,7 +616,7 @@ body.dark-mode .rcx-table__cell--align-start {
 }
 
 body.dark-mode .main-content .rcx-button {
-	background-color: var(--color-dark-medium)
+	/* background-color: var(--color-dark-medium); */
 }
 
 body.dark-mode .rcx-button--primary {

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -402,16 +402,20 @@ body.dark-mode .rcx-options .rcx-option--selected:hover {
 
 /***** Buttons *****/
 
-/* Top-right and right sidebar buttons */
-body.dark-mode /*.rcx-button--tiny-square*/ *:is(.rcx-room-header, .rcx-vertical-bar) .rcx-button:not(.rcx-button--ghost), /* Selected buttons */
-body.dark-mode /*.rcx-button--tiny-square*/ *:is(.rcx-room-header, .rcx-vertical-bar) *:is(.rcx-button--ghost, .rcx-button:hover):hover { /* Hovered buttons */
-	border-color: transparent !important;
+/* Regular button style */
+body.dark-mode .main-content .rcx-button:not(.rcx-button--ghost) { /* Default */
 	background-color: var(--color-dark) !important;
 }
+body.dark-mode .main-content .rcx-button:is(.rcx-button--ghost, .rcx-button):hover { /* Hovered or selected */
+	background-color: var(--color-darkest) !important;
+}
 
-/* body.dark-mode .main-content .rcx-button {
-	background-color: var(--color-dark-medium);
-} */
+/* Square (icon) button style */
+body.dark-mode .main-content .rcx-button--square:not(.rcx-button--ghost), /* Default */
+body.dark-mode .main-content .rcx-button--square:is(.rcx-button--ghost, .rcx-button):hover {  /* Hovered or selected */
+	background-color: var(--color-dark) !important;
+	border-color: transparent !important;
+}
 
 body.dark-mode .rcx-button {
     color: var(--info-font-color);
@@ -670,7 +674,9 @@ body.dark-mode .rcx-table__cell--align-end {
 }
 
 /* Apply info (white) font *everywhere* */
-body.dark-mode *:is(.rcx-room-header, .rcx-vertical-bar) .rcx-box:not(.rcx-button) {
+body.dark-mode .rcx-css-ps0pgs, /* Channel name */
+body.dark-mode .rcx-room-header  .rcx-box:not(.rcx-button-group):not(.rcx-button):not(.rcx-css-1fgkscl):not(.rcx-css-4pvxx3), /* omit buttons/icons (.rcx-css-1fgkscl is .rcx-icon parent) */
+body.dark-mode .rcx-vertical-bar .rcx-box:not(.rcx-button-group):not(.rcx-button):not(.rcx-css-1fgkscl):not(.rcx-css-4pvxx3) {
     color: var(--info-font-color) !important;
 }
 

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -373,6 +373,17 @@ body.dark-mode .rc-member-list__counter {
 	background-color: var(--color-dark);
 }
 
+/***** Right sidebar *****/
+
+body.dark-mode .rcx-vertical-bar,
+body.dark-mode .rcx-vertical-bar .rcx-button {
+	background-color: var(--rc-color-primary-background) !important;
+}
+
+body.dark-mode .rcx-vertical-bar .rcx-button:hover {
+    background-color: var(--rc-color-primary-dark) !important;
+}
+
 /* Targets unread message indicator in threads panel. */
 body.dark-mode button.rcx-contextual-message__follow + div.rcx-box--full {
     background-color: #1d74f5 !important;

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -90,8 +90,6 @@ select,
 	transition: opacity 300ms linear, color 150ms, background-color 150ms, border-color 150ms;
 }
 
-
-
 /******************************************
  *************Dark Mode Settings***********
  ******************************************/
@@ -429,7 +427,7 @@ body.dark-mode .rcx-button {
     color: var(--info-font-color);
 }
 
-body.dark-mode .rcx-button--ghost:hover {
+body.dark-mode .rcx-button--ghost:not(.rcx-button--square):hover {
 	color: var(--color-dark) !important;
 }
 


### PR DESCRIPTION
A lot of modifications, especially on breaking changes, or some forgotten parts (also, some rules were too extensive) : 
- Dark Theme for all modals
- Dark Theme for dropdowns (select, options)
- Modifications on sidebars, buttons, icons, etc. to get the same behaviour as we have in normal/light theme

I tried to separate each modification in a commit, so it can be easily reverted/reviewed if needed.

Feel free to add improvements or remarks 😉 