### PR TITLE
Fix lines and other items that are not styled dark

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -487,6 +487,15 @@ body.dark-mode .main-content .rcx-button--square:is(.rcx-button--ghost, .rcx-but
 	box-shadow: 0 0 0 .1rem var(--color-gray);
 }
 
+/* Menu buttons on top right (threads, search, etc.) */
+body.dark-mode .rcx-css-15vvv6z:hover,
+body.dark-mode .rcx-css-ue04py:hover,
+body.dark-mode .rcx-css-15vvv6z:active,
+body.dark-mode .rcx-css-ue04py:active {
+    border-color: var(--color-dark-medium) !important;
+    background-color: var(--color-dark-medium) !important;
+}
+
 body.dark-mode .rcx-button {
 	color: var(--info-font-color);
 }
@@ -555,8 +564,17 @@ body.dark-mode .emoji-picker .filter-item.active {
 	border-color: var(--color-light-blue);
 }
 
-body.dark-mode .rc-header--room {
-	border-bottom: 2px solid var(--color-dark-medium);
+body.dark-mode .rcx-room-header hr.rcx-divider {
+    border-color: var(--color-dark-medium);
+}
+
+body.dark-mode aside.rcx-box.rcx-box--full.rcx-vertical-bar,	/* right aside (threads, search, etc.) */
+body.dark-mode .rcx-css-ccvr3m,									/* thread list message */
+body.dark-mode .rcx-css-1j3nsmc,								/* thread list message */
+body.dark-mode .rcx-css-1bmadou,								/* thread list header */
+body.dark-mode .rcx-css-1yhzjdg									/* thread list search bar */
+{
+	border-color: var(--color-dark-medium) !important;
 }
 
 body.dark-mode .room-leader:hover {

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -568,11 +568,11 @@ body.dark-mode .rcx-room-header hr.rcx-divider {
     border-color: var(--color-dark-medium);
 }
 
-body.dark-mode aside.rcx-box.rcx-box--full.rcx-vertical-bar,	/* right aside (threads, search, etc.) */
-body.dark-mode .rcx-css-ccvr3m,									/* thread list message */
-body.dark-mode .rcx-css-1j3nsmc,								/* thread list message */
-body.dark-mode .rcx-css-1bmadou,								/* thread list header */
-body.dark-mode .rcx-css-1yhzjdg									/* thread list search bar */
+body.dark-mode aside.rcx-box.rcx-box--full.rcx-vertical-bar,    /* right aside (threads, search, etc.) */
+body.dark-mode .rcx-css-ccvr3m,                                 /* thread list message */
+body.dark-mode .rcx-css-1j3nsmc,                                /* thread list message */
+body.dark-mode .rcx-css-1bmadou,                                /* thread list header */
+body.dark-mode .rcx-css-1yhzjdg                                 /* thread list search bar */
 {
 	border-color: var(--color-dark-medium) !important;
 }


### PR DESCRIPTION
fixes #131 
fixes #128 

Fixes some of the brilliant white lines that appear in dark mode in borders and buttons.

Threads menu (applies to other side menus too) before and after:

![image](https://user-images.githubusercontent.com/39106297/115560747-e1a3f900-a282-11eb-9258-78b99cf134ff.png)

The bottom border of the channel header before and after:

![image](https://user-images.githubusercontent.com/39106297/115560876-04361200-a283-11eb-8d5c-073fdcc8e335.png)

Hover on top right menu buttons before and after:

![image](https://user-images.githubusercontent.com/39106297/115561028-27f95800-a283-11eb-99a2-91372038267f.png)

Anyone and everyone is welcome to critique the colors; @fdellwing will probably be changing them soon anyway.

