### PR TITLE
[Fix] Reactions modal background color

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -677,6 +677,14 @@ body.dark-mode .rc-scrollbars-container { /* Panels sidebar */
     background-color: var(--sidebar-background);
 }
 
+body.dark-mode .rc-scrollbars-view { /* Modals with list background like Reactions */
+    background-color: var(--color-darkest);
+}
+
+body.dark-mode .rcx-button-group { /* Backgrounds for buttons in modals with list */
+    background-color: var(--color-darkest);
+}
+
 body.dark-mode .rcx-css-15hfnte {  /* Panels sidebar header */
     background-color: var(--color-dark);
 }


### PR DESCRIPTION
With this fix you get solid Reactions modal view in Dark Mode
![image](https://user-images.githubusercontent.com/4023037/119099928-17720400-ba20-11eb-84c2-c2d6c857b53c.png)
closes https://github.com/pbaity/rocketchat-dark-mode/issues/143
