### PR TITLE
Modifications for 4.3.0

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -155,6 +155,7 @@ body.dark-mode {
 
 	/* Popover */
 	--popover-background: var(--color-dark);
+	--popover-background-hover: var(--color-dark-medium);
 	--popover-title-color: var(--color-white);
 	--popover-item-color: var(--color-white);
 
@@ -579,6 +580,10 @@ body.dark-mode .attachments__name {
 
 body.dark-mode .attachments__name:hover, .attachments__name:active {
 	color: var(--color-light-blue);
+}
+
+body.dark-mode .rc-popover__item:hover {
+	background-color: var(--popover-background-hover);
 }
 
 body.dark-mode .rc-popover__content {

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -381,9 +381,14 @@ body.dark-mode .rcx-user-card .rcx-button:hover {
 
 /* Modals */
 
+body.dark-mode .rcx-modal__header > .rcx-button--ghost.rcx-button:hover {
+	color: var(--rc-color-primary-lightest);
+}
+
 /*body.dark-mode .background-info-font-color {
 	background-color: var(--color-dark-medium);
 }*/
+
 body.dark-mode .rcx-modal__inner,
 body.dark-mode .rcx-modal__footer {
 	background: var(--color-dark);
@@ -714,10 +719,6 @@ body.dark-mode .rcx-css-15hfnte {  /* Panels sidebar header */
 
 body.dark-mode .rcx-css-10ij0kz .rcx-box { /* Panels sidebar header text and button (with cross icon) */
     color: var(--primary-font-color) !important;
-}
-
-body.dark-mode .rcx-css-15hfnte .rcx-css-4pvxx3:hover { /* Panels sidebar button (with cross icon) hovered */
-    color: var(--rc-color-primary-dark) !important;
 }
 
 body.dark-mode .rcx-css-1l00c5f,

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -381,7 +381,7 @@ body.dark-mode .rcx-user-card .rcx-button:hover {
 
 /* Modals */
 
-body.dark-mode .rcx-modal__header > .rcx-button--ghost.rcx-button:hover {
+body.dark-mode .rcx-modal__header .rcx-button--ghost.rcx-button:hover {
 	color: var(--rc-color-primary-lightest);
 }
 

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -690,6 +690,11 @@ body.dark-mode .js-logout {
 	border-color: var(--primary-font-color);
 }
 
+/* Security - 2FA */
+body.dark-mode .rcx-css-9zx50y, body.dark-mode .rcx-css-zl15hy {
+	background-color: transparent !important;
+}
+
 /************** Admin panel & Account panel ******************/
 
 .page-list a:not(.rc-button), .page-settings a:not(.rc-button) {

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -883,7 +883,7 @@ body.dark-mode .rcx-table__cell--align-end {
 /* Apply info (white) font *everywhere* */
 body.dark-mode .rcx-css-ps0pgs, /* Channel name */
 body.dark-mode .rcx-room-header  .rcx-box:not(.rcx-button-group):not(.rcx-button):not(.rcx-css-1fgkscl):not(.rcx-css-4pvxx3), /* omit buttons/icons (.rcx-css-1fgkscl is .rcx-icon parent) */
-body.dark-mode .rcx-vertical-bar .rcx-box:not(.rcx-button-group):not(.rcx-button):not(.rcx-css-1fgkscl):not(.rcx-css-4pvxx3) {
+body.dark-mode .rcx-vertical-bar .rcx-box:not(.rcx-button-group):not(.rcx-button):not(.rcx-css-1fgkscl):not(.rcx-css-4pvxx3):not(.rcx-css-trljwa) {
   color: var(--info-font-color) !important;
 	/*background-color: var(--color-darkest) !important;*/
 }

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -131,7 +131,8 @@ body.dark-mode {
 	--tags-background: var(--color-blue);
 
 	/* Sidebar */
-	--sidebar-background: var(--color-dark);
+	--sidebar-background: var(--color-dark); /* var(--color-dark-medium); */
+	--sidebar-background-hover: var(--color-darkest); /* var(--color-dark); */
 
 	/* Chip */
 	--chip-background: var(--color-blue);
@@ -523,6 +524,23 @@ body.dark-mode .rcx-button--primary:disabled {
 
 body.dark-mode .rcx-button--danger {
 	color: var(--rcx-button-colors-secondary-danger-color,var(--rcx-color-danger-500,#f5455c));
+}
+
+/***** Left sidebar *****/
+
+body.dark-mode .rcx-box.rcx-box--full.rcx-tile--elevation-2.rcx-tile {
+	background-color: var(--sidebar-background);
+	/* 255 - rgba(47,52,61,.12) */
+	box-shadow: 0 0 2px 0 rgba(208,203,194,.08), 0 0 12px 0 rgba(208,203,194,.12);
+}
+
+body.dark-mode .rcx-box.rcx-box--full.rcx-tile--elevation-2.rcx-tile .rcx-option__title,
+body.dark-mode .rcx-box.rcx-box--full.rcx-tile--elevation-2.rcx-tile .rcx-option {
+	color: var(--primary-font-color);
+}
+
+body.dark-mode .rcx-box.rcx-box--full.rcx-tile--elevation-2.rcx-tile .rcx-option:hover {
+    background-color: var(--sidebar-background-hover);
 }
 
 /***** Right sidebar *****/

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -476,10 +476,6 @@ body.dark-mode .rcx-options .rcx-option--selected:hover {
 	background-color: var(--color-dark) !important;
 }
 
-body.dark-mode .rcx-css-dpt4t8 { /* User selector in create direct message modal */
-	color: var(--color-dark);
-}
-
 /***** Buttons *****/
 
 /* Regular button style */
@@ -575,6 +571,7 @@ body.dark-mode button.rcx-contextual-message__follow + div.rcx-box--full {
 }
 
 /***** Chat file list *****/
+
 
 body.dark-mode .attachments__item:hover, .attachments__item:active {
 	background-color: var(--color-darkest);
@@ -781,6 +778,11 @@ body.dark-mode .rcx-input-box__wrapper {
 body.dark-mode .rcx-box * .rcx-input-box {
 	background-color: var(--color-dark);
 	color: var(--rc-color-primary);
+}
+
+/* .rcx-autocomplete, .rcx-input-box:not(.rcx-input-box--undecorated), .rcx-input-box__wrapper, .rcx-select */
+body.dark-mode .rcx-autocomplete {
+	background-color: transparent;
 }
 
 body.dark-mode .rcx-table__cell {

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -704,6 +704,12 @@ body.dark-mode .rcx-css-9zx50y, body.dark-mode .rcx-css-zl15hy {
 	background-color: transparent !important;
 }
 
+/***** Omnichannel *****/
+
+body.dark-mode .rcx-css-110cgdy {
+	background-color: transparent !important;
+}
+
 /************** Admin panel & Account panel ******************/
 
 .page-list a:not(.rc-button), .page-settings a:not(.rc-button) {

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -572,6 +572,13 @@ body.dark-mode button.rcx-contextual-message__follow + div.rcx-box--full {
 
 /***** Chat file list *****/
 
+body.dark-mode .rcx-css-18t0quo {
+	background-color: var(--color-darkest);
+}
+
+body.dark-mode .rcx-css-18t0quo:hover {
+	background-color: var(--color-dark-medium);
+}
 
 body.dark-mode .attachments__item:hover, .attachments__item:active {
 	background-color: var(--color-darkest);

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -385,6 +385,11 @@ body.dark-mode .rcx-modal__header .rcx-button--ghost.rcx-button:hover {
 	color: var(--rc-color-primary-lightest);
 }
 
+/* Temporary fix for modals where "Cancel" button is missing 'rcx-button--ghost' class */
+body.dark-mode .rcx-modal__footer .rcx-box.rcx-box--full.rcx-box--animated.rcx-button.rcx-button-group__item:first-of-type:not(.rcx-button--ghost) {
+	color: var(--rc-color-primary-lightest);
+}
+
 /*body.dark-mode .background-info-font-color {
 	background-color: var(--color-dark-medium);
 }*/


### PR DESCRIPTION
Some CSS modifications to fix things that have been broken by RC 4.3.0 😉 
Thanks to @ae5960e8-a6fc-491f-b252-898ecf59af95 for pointing some of them in #161

- Left sidebar menus (Account, Display) colors (background, text, hover)
- Message option menu (three dots) colors (hover)
- Modals
  - Close button (cross icon on top right) color (hover)
  - Cancel button (when `.rcx-button--ghost` class is missing) color (text) (-> #144 )
- 2FA codes display box in Account menu (background)
- ...

Don't hesitate to tell me if you find something wrong or not working as expected !