### PR TITLE
Embedded mode improvement

### DIFF
--- a/dark-mode-toggle.js
+++ b/dark-mode-toggle.js
@@ -90,7 +90,12 @@ function updateButton(mode) {
 }
 
 function addDarkModeToggle() {
-	const sidebarToolbar = $('.rcx-sidebar-topbar .rcx-button-group').first();
+	const normalModeSidebarSelector = '.rcx-sidebar-topbar .rcx-button-group';
+	const embeddedModeSidebarSelector = '.rcx-room-header .rcx-button-group';
+
+	const sidebarToolbar = ($(normalModeSidebarSelector).length > 0)
+						? $(normalModeSidebarSelector).first()
+						: $(embeddedModeSidebarSelector).first();
 
 	// wait for the sidebar toolbar to be visible
 	// this will also be false if the toolbar doesn't exist yet

--- a/dark-mode-toggle.js
+++ b/dark-mode-toggle.js
@@ -14,6 +14,9 @@ const DARK_MODE_BUTTON = "dark-mode-button"; // could be `button-${DARK_MODE_CSS
 
 const DARK_MODE_MODES = ["auto", "dark", "light"];
 
+let DARK_MODE_BUTTON_RETRY_COUNT = 0;
+const DARK_MODE_BUTTON_RETRY_MAX = 10;
+
 const systemModeMediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
 
 const modeSymbols = {
@@ -89,7 +92,7 @@ function updateButton(mode) {
 	darkModeButton.attr('data-title', `${darkModeToggleText}, current: ${mode}`);
 }
 
-function addDarkModeToggle() {
+function addDarkModeToggle() {	
 	const normalModeSidebarSelector = '.rcx-sidebar-topbar .rcx-button-group';
 	const embeddedModeSidebarSelector = '.rcx-room-header .rcx-button-group';
 
@@ -99,8 +102,9 @@ function addDarkModeToggle() {
 
 	// wait for the sidebar toolbar to be visible
 	// this will also be false if the toolbar doesn't exist yet
-	if(!sidebarToolbar.is(':visible')) {
+	if(!sidebarToolbar.is(':visible') && DARK_MODE_BUTTON_RETRY_COUNT < DARK_MODE_BUTTON_RETRY_MAX) {
 		setTimeout(addDarkModeToggle, 250);
+		DARK_MODE_BUTTON_RETRY_COUNT += 1;
 		return;
 	}
 
@@ -118,12 +122,13 @@ function addDarkModeToggle() {
 		toggleDarkMode();
 		$(this).blur();
 	});
-
-	// Switch mode on system theme changes
-	systemModeMediaQuery.addEventListener("change", maybeModeChange);
-
-	// Trigger initial mode change if necessary
-	maybeModeChange();
 }
 
+// Switch mode on system theme changes
+systemModeMediaQuery.addEventListener("change", maybeModeChange);
+
+// Trigger initial mode change if necessary
+maybeModeChange();
+
+// Add toggle button
 $(addDarkModeToggle);

--- a/dark-mode-toggle.js
+++ b/dark-mode-toggle.js
@@ -14,9 +14,6 @@ const DARK_MODE_BUTTON = "dark-mode-button"; // could be `button-${DARK_MODE_CSS
 
 const DARK_MODE_MODES = ["auto", "dark", "light"];
 
-let DARK_MODE_BUTTON_RETRY_COUNT = 0;
-const DARK_MODE_BUTTON_RETRY_MAX = 10;
-
 const systemModeMediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
 
 const modeSymbols = {
@@ -40,6 +37,12 @@ const darkModeToggleText = {
 	'hi': 'डार्क मोड',
 	'zh': '切换暗色主题'
 }[defaultUserLanguage()] || 'Toggle Dark Mode';
+
+const normalModeSidebarSelector = '.rcx-sidebar-topbar .rcx-button-group';
+const embeddedModeSidebarSelector = '.rcx-room-header .rcx-button-group';
+
+let addDarkModeToggleRetryCount = 0;
+const addDarkModeToggleRetryMax = 10;
 
 const toggleButton = `<button id="${DARK_MODE_BUTTON}" class="rcx-box rcx-box--full rcx-button--small-square rcx-button--square rcx-button--small rcx-button--ghost rcx-button rcx-button-group__item rcx-@ue04p" aria-label="${darkModeToggleText}">D</button>`;
 
@@ -92,19 +95,16 @@ function updateButton(mode) {
 	darkModeButton.attr('data-title', `${darkModeToggleText}, current: ${mode}`);
 }
 
-function addDarkModeToggle() {	
-	const normalModeSidebarSelector = '.rcx-sidebar-topbar .rcx-button-group';
-	const embeddedModeSidebarSelector = '.rcx-room-header .rcx-button-group';
-
+function addDarkModeToggle() {
 	const sidebarToolbar = ($(normalModeSidebarSelector).length > 0)
 						? $(normalModeSidebarSelector).first()
 						: $(embeddedModeSidebarSelector).first();
 
 	// wait for the sidebar toolbar to be visible
 	// this will also be false if the toolbar doesn't exist yet
-	if(!sidebarToolbar.is(':visible') && DARK_MODE_BUTTON_RETRY_COUNT < DARK_MODE_BUTTON_RETRY_MAX) {
+	if(!sidebarToolbar.is(':visible') && addDarkModeToggleRetryCount < addDarkModeToggleRetryMax) {
 		setTimeout(addDarkModeToggle, 250);
-		DARK_MODE_BUTTON_RETRY_COUNT += 1;
+		addDarkModeToggleRetryCount += 1;
 		return;
 	}
 


### PR DESCRIPTION

This PR fixes #94  and #158 :

- Selected theme (dark, light, auto) is now always applied in embedded mode
- [If top navbar is enabled in embedded mode](https://developer.rocket.chat/rocket.chat/embedded-layout), the dark mode toggle button will be added to this navbar

Details:

- The script will now search for a sidebar, or a top navbar if the sidebar is not found
- When the script couldn't find a sidebar/navbar, there was an infinite loop, and we would never reach the "apply theme" part of the code, so I moved it outside the function (and I also added a retry count to avoid this loop). 