### PR TITLE
making the purne messeges warning readable 4.8.1

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -112,7 +112,8 @@ body.dark-mode {
 	--rc-color-primary-lightest: var(--color-dark-medium);
 	--rcx-color-neutral-100: var(--rc-color-primary-dark);
 	--rcx-color-danger-200: var(--rc-color-alert);
-
+	--rcx-color-warning-200: var(--rc-color-alert);
+	
 	/* Forms - Button */
 	--button-disabled-background: var(--color-dark-70);
 	--button-disabled-text-color: var(--color-dark-80);


### PR DESCRIPTION
going from white on cream (#ffecad) to white on dark red