### PR TITLE
Change background color of new 5.1.0 grid items

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -912,6 +912,12 @@ body.dark-mode .rcx-css-1wm5na { /* Account settings page header title */
 	color: var(--primary-font-color) !important;
 }
 
+/************** New 5.1.0 homepage and Settings grid **************/
+
+body.dark-mode div.rcx-box.rcx-box--full div.rcx-css-kmnwgn { /* Change background color of new grid items */
+	background-color: var(--color-darker) !important; 
+}
+
 /************** Admin panel ******************/
 
 /* Admin panel page items (deployment-card) */


### PR DESCRIPTION
This fixes the background color for the new 5.1.0 homepage and Settings pages.

![188285434-f2900c42-189c-4128-9b8a-df97ba474643](https://user-images.githubusercontent.com/9246549/188866174-c0d120b6-d617-42d1-a13c-fcd788331182.png)
