### PR TITLE
Fix quotes in 5.2.0

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -222,9 +222,16 @@ body.dark-mode .rcx-room-header .rcx-tag--default {
 
 /* Blockquote */
 body.dark-mode .rcx-css-1d5cod7,
-body.dark-mode .rcx-css-765mvi {
+body.dark-mode .rcx-css-765mvi,
+body.dark-mode .rcx-css-91fbdt {
 	background-color: var(--color-darkest) !important;
 	color: var(--secondary-font-color) !important;
+}
+
+body.dark-mode .rcx-css-91fbdt > blockquote {
+	background-color: var(--color-darkest) !important;
+	border-top: none;
+	border-bottom: none;
 }
 
 body.dark-mode .rcx-css-11c35pn > .rcx-attachment__details,

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -221,23 +221,29 @@ body.dark-mode .rcx-room-header .rcx-tag--default {
 }
 
 /* Blockquote */
-body.dark-mode .rcx-css-1d5cod7 {
+body.dark-mode .rcx-css-1d5cod7,
+body.dark-mode .rcx-css-765mvi {
 	background-color: var(--color-darkest) !important;
 	color: var(--secondary-font-color) !important;
 }
 
-body.dark-mode .rcx-css-11c35pn > .rcx-attachment__details {
+body.dark-mode .rcx-css-11c35pn > .rcx-attachment__details,
+body.dark-mode .rcx-css-1q4bwy6 > .rcx-attachment__details {
 	border-color: transparent !important;
 	border-inline-start-color: var(--color-gray) !important;
 }
 
 body.dark-mode .rcx-css-11c35pn:hover .rcx-attachment__details,
-body.dark-mode .rcx-css-11c35pn:focus .rcx-attachment__details {
+body.dark-mode .rcx-css-11c35pn:focus .rcx-attachment__details,
+body.dark-mode .rcx-css-1q4bwy6:hover .rcx-attachment__details,
+body.dark-mode .rcx-css-1q4bwy6:focus .rcx-attachment__details {
     border-color: var(--secondary-font-color) !important;
 }
 
 body.dark-mode .rcx-css-11c35pn:hover .rcx-attachment__details,
-body.dark-mode .rcx-css-11c35pn:focus .rcx-attachment__details {
+body.dark-mode .rcx-css-11c35pn:focus .rcx-attachment__details,
+body.dark-mode .rcx-css-1q4bwy6:hover .rcx-attachment__details,
+body.dark-mode .rcx-css-1q4bwy6:focus .rcx-attachment__details {
 	background-color: var(--color-dark) !important;
 }
 


### PR DESCRIPTION
These changes make quotes great again.

New CSS classes from Rocket.Chat 5.2.0 are added to the existing ones from 5.1.x in order to make the CSS work with both versions.

Fixes https://github.com/pbaity/rocketchat-dark-mode/issues/195.