### PR TITLE
Set colors for announcements

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -133,6 +133,12 @@ body.dark-mode {
 
 	--rcx-tabs-hover-border-color: var(--primary-font-color);
 	
+	/* Announcements */
+	--rcx-color-announcement-text: var(--info-font-color);
+	--rcx-color-announcement-background: var(--color-dark-medium);
+	--rc-color-announcement-text-hover: var(--info-font-color);
+	--rc-color-announcement-background-hover: var(--color-dark-light);
+
 	/* Emojis */
 	--rcx-button-icon-background-color: transparent;
 	--rcx-message-reaction-background-color: var(--rc-color-primary-dark);


### PR DESCRIPTION
Sets some colors for announcements in order to align their style with banners (as suggested in https://github.com/pbaity/rocketchat-dark-mode/issues/203#issuecomment-1314985679):

![image](https://user-images.githubusercontent.com/404840/202028856-2cb06005-b5c1-46c5-a73a-fdfcc30b9192.png)

When hovering:

![image](https://user-images.githubusercontent.com/404840/202029002-6a681ae7-f9b2-4744-a192-a235d1222dbf.png)

Note that there seems to be some inconsistency in Rocket.Chat about the names for the CSS variables. This leads to two of the variables having the prefix `--rc-` while the other two have the prefix `--rcx-`. This also leads to the problem that the colors of an announcement cannot be changed in the workspace settings. I documented this in https://github.com/RocketChat/Rocket.Chat/issues/27269. When that issue is fixed, the affected variables will also need to be changed here.

Fixes #203.